### PR TITLE
merge for v0.1.1

### DIFF
--- a/eomaps/__init__.py
+++ b/eomaps/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1"
+__version__ = "0.1.1"
 __author__ = "Raphael Quast"
 
 from .eomaps import Maps

--- a/eomaps/callbacks.py
+++ b/eomaps/callbacks.py
@@ -137,6 +137,7 @@ class callbacks(object):
         pos_precision=4,
         val_precision=4,
         permanent=False,
+        val_fmt=None,
         **kwargs,
     ):
         """
@@ -155,11 +156,22 @@ class callbacks(object):
             The floating-point precision of the coordinates.
             The default is 4.
         val_precision : int
-            The floating-point precision of the parameter-values.
-            The default is 4.
+            The floating-point precision of the parameter-values (only used if
+            "val_fmt=None"). The default is 4.
         permanent : bool
             Indicator if the annotation should be temporary (False) or
             permanent (True). The default is False
+        val_fmt : callable, optional
+            A callabel that is used to transform the value into the desired
+            output of the following form:
+
+                >>> def val_fmt(m, val):
+                >>>     # m   ... the Maps object
+                >>>     # val ... the value
+                >>>     return f"{val:.2f}"
+
+            The default is None
+
         **kwargs
             kwargs passed to matplotlib.pyplot.annotate(). The default is:
 
@@ -213,9 +225,12 @@ class callbacks(object):
         printstr += f"{xlabel} = {x}\n{ylabel} = {y}\n"
         printstr += f"ID = {ID}\n"
 
-        if isinstance(val, (int, float)):
-            val = np.format_float_positional(val, trim="-", precision=val_precision)
-        printstr += f"{self.m.data_specs['parameter']} = {val}"
+        if val_fmt is not None:
+            printstr += val_fmt(self.m, val)
+        else:
+            if isinstance(val, (int, float)):
+                val = np.format_float_positional(val, trim="-", precision=val_precision)
+            printstr += f"{self.m.data_specs['parameter']} = {val}"
 
         self.annotation.set_text(printstr)
         # self.annotation.get_bbox_patch().set_alpha(0.75)

--- a/eomaps/callbacks.py
+++ b/eomaps/callbacks.py
@@ -35,9 +35,11 @@ class callbacks(object):
         self.m = m
 
     def __repr__(self):
-        return "available callbacks:\n    - " + "\n    - ".join(
-            [i for i in self.__dir__() if not i.startswith("_")]
-        )
+        return "available callbacks:\n    - " + "\n    - ".join(self.cb_list)
+
+    @property
+    def cb_list(self):
+        return ["load", "print_to_console", "annotate", "plot", "get_values", "mark"]
 
     def load(
         self,

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -1458,8 +1458,6 @@ class Maps(object):
 
         # ------------- add a callback
         def onpick(event):
-            print(event.double_click, event.mouse_button)
-
             if (event.double_click == double_click) and (
                 event.mouse_button == mouse_button
             ):

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -1441,9 +1441,7 @@ class Maps(object):
             assert hasattr(self.cb, callback), (
                 f"The function '{callback}' does not exist as a pre-defined callback."
                 + " Use one of:\n    - "
-                + "\n    - ".join(
-                    [i for i in self.cb.__dir__() if not i.startswith("_")]
-                )
+                + "\n    - ".join(self.cb.cb_list)
             )
             callback = getattr(self.cb, callback)
         elif callable(callback):
@@ -1467,7 +1465,7 @@ class Maps(object):
         # if multiple assignments are properly handled
         multi_cb_functions = ["mark"]
 
-        no_multi_cb = [key for key in callbacks.__dict__ if not key.startswith("_")]
+        no_multi_cb = [*self.cb.cb_list]
         for i in multi_cb_functions:
             no_multi_cb.pop(no_multi_cb.index(i))
 

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -1252,10 +1252,6 @@ class Maps(object):
         if maskshp is not None:
             overlay_df = gpd.overlay(overlay_df[["geometry"]], maskshp)
 
-        import pdb
-
-        pdb.set_trace()
-
         _ = overlay_df.plot(ax=ax, aspect=ax.get_aspect(), **styledict)
 
         if legend is True:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="EOmaps",
-    version=0.1,
+    version="0.1.1",
     description="a general-purpose library to plot and analyze large geographical datasets.",
     packages=find_packages(),
     package_dir={"eomaps": "eomaps"},

--- a/tests/test_basic_functions.py
+++ b/tests/test_basic_functions.py
@@ -42,7 +42,7 @@ class TestBasicPlotting(unittest.TestCase):
 
         # attach all callbacks
         double_click, mouse_button = True, 1
-        for n, cb in enumerate([i for i in m.cb.__dir__() if not i.startswith("_")]):
+        for n, cb in enumerate(m.cb.cb_list):
             if n == 1:
                 double_click = False
             if n == 2:


### PR DESCRIPTION
## new
- allow multiple callbacks of the same function (using different mouse-button assignments)
- add option to make annotations permanent `m.cb.annotate(... , permanent=True)`
- add option to format annotation display via `m.cb.annotate(..., val_fmt=<callable>)`
- add `m.cb.mark` callback (e.g. to overlay markers around selected points)
- all callback-returns are now accessible via `m.cb...`
- add `m.cb.cb_list` (e.g. a hardcoded list of available callback functions)
## fixes
- better fetching of background for blitting (now also works with multiple callbacks)
- 