### PR TITLE
add move callbacks

### DIFF
--- a/eomaps/callbacks.py
+++ b/eomaps/callbacks.py
@@ -763,6 +763,23 @@ class click_callbacks(_click_callbacks):
         super().__init__(*args, **kwargs)
 
 
+class move_callbacks(_click_callbacks):
+    """
+    A collection of callback functions that are executed when clicking anywhere
+    on the map.
+    """
+
+    _cb_list = [
+        "print_to_console",
+        "annotate",
+        "mark",
+        "peek_layer",
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
 class keypress_callbacks:
     """
     A collection of callback functions that are executed when the assigned


### PR DESCRIPTION
- allow callbacks that are executed if you move with the mouse over the map
  (e.g. without clicking)