### PR TITLE
merge for v3.3

### DIFF
--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -11,3 +11,28 @@ the plot-settings must be adjusted to ensure that ``matplotlib`` plots remain in
   interactive ``matplotlib`` widgets instead, go to the preferences and set the "Graphics backend" to "Automatic" :
 
 .. image:: _static/spyder_preferences.png
+
+📓 Using EOmaps with Jupyter Notebooks
+--------------------------------------
+
+While EOmaps works best with matplotlib's ``Qt5Agg`` backend, most of the functionalities work
+reasonably well if you want the figures embedded in a Jupyter Notebook.
+
+
+🔸 For jupyter-lab (and classic notebooks) you can use the ``ipympl`` backend
+
+- To install, simply use ``conda install -c conda-forge ipympl``
+- Once it's installed, (and before you start plotting) use the magic ``%matplotlib widget`` to activate the backend.
+- See here for more details: https://github.com/matplotlib/ipympl
+
+🔸 For classical notebooks, there's also the ``nbagg`` backend provided by matplotlib
+
+- To use it, simply execute the magic ``%matpltolib notebook`` before starting to plot.
+
+🔸 Finally, you can also use the magic ``%matplotlib qt`` and use the ``qt5agg`` backend within Jupyter Notebooks!
+
+- This way the plots will NOT be embedded in the notebook but they are created as separate widgets.
+
+
+Checkout the `matplotlib doc <https://matplotlib.org/stable/users/explain/interactive.html#jupyter-notebooks-jupyterlab>`_
+for more info!

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1004,19 +1004,8 @@ A compass can be added to the map via ``m.add_compass()``:
     |   m.add_compass()                    |                                         |
     +--------------------------------------+-----------------------------------------+
 
-
-
 The compass object is dynamically updated if you pan/zoom the map, and it can be
 dragged around on the map with the mouse.
-
-.. code-block:: python
-
-    m = Maps()
-    m.add_feature.preset.coastline()
-    c1 = m.add_compass(pos=(.25, .25), style="compass")
-    c2 = m.add_compass(pos=(.5, .25), style="north arrow")    # to remove it, use
-
-    c1.set_patch(facecolor="g", edgecolor="k", linewidth=2)
 
 The returned ``compass`` object has the following useful methods assigned:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -505,6 +505,7 @@ Pre-defined (global) WebMap services:
     EEA_DiscoMap
     ESRI_ArcGIS
     S1GBM
+    GEBCO
 
 Services specific for Austria (Europa)
 

--- a/eomaps/_cb_container.py
+++ b/eomaps/_cb_container.py
@@ -600,7 +600,7 @@ class cb_click_container(_click_container):
                 obj = self._getobj(m)
                 if obj is None:
                     continue
-                obj._onrelease()
+                obj._onrelease(event)
 
         else:
             for key, m in self._fwd_cbs.items():

--- a/eomaps/_cb_container.py
+++ b/eomaps/_cb_container.py
@@ -570,7 +570,7 @@ class cb_click_container(_click_container):
                 # forward callbacks to the connected maps-objects
                 obj._fwd_cb(event)
 
-            self._m.parent.BM.update(clear=False)
+            # self._m.parent.BM.update(clear=False)
 
         if self._cid_button_press_event is None:
             # ------------- add a callback

--- a/eomaps/_cb_container.py
+++ b/eomaps/_cb_container.py
@@ -88,7 +88,7 @@ class _cb_container(object):
                 if m1 is not m2:
                     self._getobj(m1)._fwd_cbs[id(m2)] = m2
 
-    def add_temporary_artist(self, artist, layer=None):
+    def add_temporary_artist(self, artist):
         """
         make an artist temporary
         (e.g. remove it from the map at the next event)
@@ -97,12 +97,8 @@ class _cb_container(object):
         ----------
         artist : matplotlib.artist
             the artist to use
-        layer : int, optional
-            the layer to put the artist on. The default is None.
         """
-        if layer is None:
-            layer = self._m.layer
-        self._m.BM.add_artist(artist, layer=layer)
+        self._m.BM.add_artist(artist)
         self._temporary_artists.append(artist)
 
 

--- a/eomaps/_containers.py
+++ b/eomaps/_containers.py
@@ -1148,6 +1148,51 @@ else:
 
         @property
         @lru_cache()
+        def GEBCO(self):
+            """
+            Global ocean & land terrain models
+            https://www.gebco.net/
+
+            GEBCO aims to provide the most authoritative, publicly available bathymetry
+            data sets for the world’s oceans.
+
+            GEBCO's current gridded bathymetric data set, the GEBCO_2021 Grid, is a
+            global terrain model for ocean and land, providing elevation data, in
+            meters, on a 15 arc-second interval grid. It is accompanied by a Type
+            Identifier (TID) Grid that gives information on the types of source data
+            that the GEBCO_2021 Grid is based.
+
+            For this release, we are making available a version of the grid with
+            under-ice topography/bathymetry information for Greenland and Antarctica.
+
+
+            Note
+            ----
+            **LICENSE-info (without any warranty for correctness!!)**
+
+            The GEBCO Grid is placed in the public domain and may be used free of charge.
+
+            If imagery from the WMS is included in web sites, reports and digital and
+            printed imagery then we request that the source of the data set is
+            acknowledged and be of the form
+
+            "Imagery reproduced from the GEBCO_2021 Grid, GEBCO Compilation Group (2021)
+            GEBCO 2021 Grid (doi:10.5285/c6612cbe-50b3-0cff-e053-6c86abc09f8f)"
+
+            (check: https://www.gebco.net/ for full details)
+
+            """
+            WMS = _WebServiec_collection(
+                m=self._m,
+                service_type="wms",
+                url="https://www.gebco.net/data_and_products/gebco_web_services/web_map_service/mapserv?request=getcapabilities&service=wms&version=1.1.1",
+            )
+
+            WMS.__doc__ = type(self).GEBCO.__doc__
+            return WMS
+
+        @property
+        @lru_cache()
         def NASA_GIBS(self):
             """
             NASA Global Imagery Browse Services (GIBS)

--- a/eomaps/_containers.py
+++ b/eomaps/_containers.py
@@ -1420,7 +1420,9 @@ else:
                     )
 
                     self.stamen_watercolor = _xyz_tile_service(
-                        self._m, "http://c.tile.stamen.com/watercolor/{z}/{x}/{y}.jpg"
+                        self._m,
+                        "http://c.tile.stamen.com/watercolor/{z}/{x}/{y}.jpg",
+                        maxzoom=18,
                     )
 
                     self.stamen_terrain = _xyz_tile_service(

--- a/eomaps/_containers.py
+++ b/eomaps/_containers.py
@@ -583,7 +583,7 @@ class _NaturalEarth_presets:
             "ocean",
             fc=color,
             ec="none",
-            zorder=0,
+            zorder=-1,
             reproject="cartopy",
         )
 
@@ -610,7 +610,7 @@ class _NaturalEarth_presets:
             "land",
             fc=color,
             ec="none",
-            zorder=0,
+            zorder=-1,
         )
 
     @property

--- a/eomaps/_containers.py
+++ b/eomaps/_containers.py
@@ -132,7 +132,7 @@ class map_objects(object):
         else:
             _, ax_cb, ax_cb_plot, orientation, _ = cb
 
-        if orientation == "horizontal":
+        if orientation == "vertical":
             pcb = ax_cb.get_position()
             pcbp = ax_cb_plot.get_position()
             if pos is None:
@@ -150,7 +150,7 @@ class map_objects(object):
                 [pos[0], pos[1] + hcb, pos[2], hp],
             )
 
-        elif orientation == "vertical":
+        elif orientation == "horizontal":
             pcb = ax_cb.get_position()
             pcbp = ax_cb_plot.get_position()
             if pos is None:

--- a/eomaps/_webmap.py
+++ b/eomaps/_webmap.py
@@ -637,6 +637,190 @@ class _REST_API(object):
         return all_services
 
 
+from cartopy.io import RasterSource
+from cartopy.io.ogc_clients import _warped_located_image, _target_extents
+
+
+class TileFactory(GoogleWTS):
+    def __init__(self, url, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._url = url
+
+    def _image_url(self, tile):
+        x, y, z = tile
+
+        if isinstance(self._url, str):
+            return self._url.format(x=x, y=y, z=z)
+        if callable(self._url):
+            return self._url(x=x, y=y, z=z)
+
+
+class xyzRasterSource(RasterSource):
+    """
+    A RasterSource that can be used with a SlipperyImageArtist to fetch tiles.
+    """
+
+    def __init__(self, url, crs, maxzoom=19, transparent=True):
+        """
+        Parameters
+        ----------
+        service: string or WebMapService instance
+            The WebMapService instance, or URL of a WMS service,
+            from whence to retrieve the image.
+        layers: string or list of strings
+            The name(s) of layers to use from the WMS service.
+        """
+        self.url = url
+
+        self._crs = crs
+        self._maxzoom = maxzoom
+
+        if transparent is True:
+            self.desired_tile_form = "RGBA"
+        else:
+            self.desired_tile_form = "RGB"
+
+        self._factory = TileFactory(self.url, desired_tile_form=self.desired_tile_form)
+
+    # function to estimate a proper zoom-level
+    @staticmethod
+    def _getz(d, zmax):
+        z = int(np.clip(np.ceil(np.log2(1 / d * 40075016.68557849)), 0, zmax))
+        return z
+
+    def getz(self, extent, target_resolution, zmax):
+        import shapely.geometry as sgeom
+
+        x0, x1, y0, y1 = extent
+        d = x1 - x0
+
+        domain = sgeom.box(x0, y0, x1, y1)
+
+        z = self._getz(d, zmax)
+        ntiles = len(list(self._factory.find_images(domain, z)))
+
+        # use the target resolution to increase the zoom-level until we use a
+        # reasonable amount of tiles
+        nimgs = np.ceil(max(target_resolution) / 256) ** 2
+
+        while ntiles < nimgs:
+            if z >= self._maxzoom:
+                break
+
+            z += 1
+            ntiles = len(list(self._factory.find_images(domain, z)))
+
+        return min(z, self._maxzoom)
+
+    def _native_srs(self, projection):
+        # Return the SRS which corresponds to the given projection when
+        # known, otherwise return None.
+        return self._crs
+
+    def validate_projection(self, projection):
+        # no need to validate the projection, we're always in 3857
+        pass
+
+    def _image_and_extent(
+        self,
+        wms_proj,
+        wms_srs,
+        wms_extent,
+        output_proj,
+        output_extent,
+        target_resolution,
+    ):
+        import shapely.geometry as sgeom
+
+        x0, x1, y0, y1 = wms_extent
+
+        domain = sgeom.box(x0, y0, x1, y1)
+
+        img, extent, origin = self._factory.image_for_domain(
+            domain,
+            self.getz(wms_extent, target_resolution, self._maxzoom),
+        )
+
+        # import PIL.Image
+        # output_extent = _target_extents(extent, self._crs, output_proj)[0]
+        # return _warped_located_image(PIL.Image.fromarray(img), wms_srs, extent,
+        #                               output_proj,
+        #                               output_extent,
+        #                               target_resolution
+        #                               )
+
+        # ------------- ---------------------------------------------------------------
+        # ------------- the following is copied from cartopy's version of ax.imshow
+        # ------------- since the above lines don't work for some reason...
+
+        if output_proj == wms_srs:
+            pass
+        else:
+            img = np.asanyarray(img)
+            if origin == "upper":
+                # It is implicitly assumed by the regridding operation that the
+                # origin of the image is 'lower', so simply adjust for that
+                # here.
+                img = img[::-1]
+
+            # target_extent = self._m.ax.get_extent(self._m.ax.projection)
+            # reproject the extent to the output-crs
+            target_extent = _target_extents(extent, self._crs, output_proj)[0]
+
+            regrid_shape = [int(i * 2) for i in target_resolution]
+            # check  self._m.ax._regrid_shape_aspect for a more proper regrid_shape
+
+            # Lazy import because scipy/pykdtree in img_transform are only
+            # optional dependencies
+            from cartopy.img_transform import warp_array
+
+            original_extent = extent
+            img, extent = warp_array(
+                img,
+                source_proj=self._crs,
+                source_extent=original_extent,
+                target_proj=output_proj,
+                target_res=regrid_shape,
+                target_extent=target_extent,
+                mask_extrapolated=True,
+            )
+
+            if origin == "upper":
+                # revert to the initial origin
+                img = img[::-1]
+
+        from cartopy.io.ogc_clients import LocatedImage
+
+        return LocatedImage(img, extent)
+
+    def fetch_raster(self, projection, extent, target_resolution):
+        import math
+
+        target_resolution = [math.ceil(val) for val in target_resolution]
+
+        if projection == self._crs:
+            wms_extents = [extent]
+        else:
+            # Calculate the bounding box(es) in WMS projection.
+            wms_extents = _target_extents(extent, projection, self._crs)
+
+        located_images = []
+
+        for wms_extent in wms_extents:
+            located_images.append(
+                self._image_and_extent(
+                    self._crs,
+                    self._crs,
+                    wms_extent,
+                    projection,
+                    extent,
+                    target_resolution,
+                )
+            )
+
+        return located_images
+
+
 class _xyz_tile_service:
     """
     general class for using x/y/z tile-service urls as WebMap layers
@@ -644,39 +828,14 @@ class _xyz_tile_service:
 
     def __init__(self, m, url, maxzoom=19):
         self._m = m
-
-        self._redraw = True
         self._factory = None
         self._artist = None
 
-        self._event_attached = None
-        self._layer = 0
-
         self.url = url
-
         self._maxzoom = maxzoom
 
     def _reinit(self, m):
         return _xyz_tile_service(m, self.url, self._maxzoom)
-
-    class TileFactory(GoogleWTS):
-        def __init__(self, url, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self._url = url
-
-        def _image_url(self, tile):
-            x, y, z = tile
-
-            if isinstance(self._url, str):
-                return self._url.format(x=x, y=y, z=z)
-            if callable(self._url):
-                return self._url(x=x, y=y, z=z)
-
-    # function to estimate a proper zoom-level
-    @staticmethod
-    def getz(d, zmax):
-        z = int(np.clip(np.ceil(np.log2(4 / d * 40075016)), 1, zmax))
-        return z
 
     def __call__(
         self,
@@ -723,75 +882,19 @@ class _xyz_tile_service:
                     layer, transparent, alpha, interpolation, **kwargs
                 )
         else:
-            self.kwargs = dict(interpolation=interpolation, alpha=alpha)
+            self.kwargs = dict(interpolation=interpolation, alpha=alpha, origin="lower")
             self.kwargs.update(kwargs)
 
-            if transparent is True:
-                self.desired_tile_form = "RGBA"
-            else:
-                self.desired_tile_form = "RGB"
+            self._raster_source = xyzRasterSource(
+                self.url,
+                crs=ccrs.GOOGLE_MERCATOR,
+                maxzoom=self._maxzoom,
+                transparent=transparent,
+            )
 
-            if self._event_attached is None:
-                self._event_attached = self._m.figure.f.canvas.mpl_connect(
-                    "draw_event", self.ondraw
-                )
-                toolbar = self._m.figure.f.canvas.toolbar
-
-                if toolbar is not None:
-                    toolbar.release_zoom = self.zoom_decorator(toolbar.release_zoom)
-                    toolbar.release_pan = self.zoom_decorator(toolbar.release_pan)
-                    toolbar._update_view = self.update_decorator(toolbar._update_view)
+            self._artist = self._m.ax.add_raster(self._raster_source, **self.kwargs)
 
             if layer is None:
-                self._layer = self._m.layer
-            else:
-                self._layer = layer
+                layer = self._m.layer
 
-            self._factory = self.TileFactory(
-                self.url, desired_tile_form=self.desired_tile_form
-            )
-            self.redraw()
-
-    def redraw(self):
-        # get and remember the extent
-        extent = self._m.figure.ax.get_extent(crs=self._m.CRS.GOOGLE_MERCATOR)
-        if self._artist is not None:
-            self._m.BM.remove_bg_artist(self._artist)
-            self._artist.remove()
-            self._artist = None
-
-        img, extent, origin = self._factory.image_for_domain(
-            self._m.figure.ax._get_extent_geom(self._factory.crs),
-            self.getz(extent[1] - extent[0], self._maxzoom),
-        )
-        self._artist = self._m.figure.ax.imshow(
-            img,
-            extent=extent,
-            origin=origin,
-            transform=self._factory.crs,
-            **self.kwargs,
-        )
-
-        self._m.BM.add_bg_artist(self._artist, self._layer)
-
-    def ondraw(self, event):
-        if self._event_attached is not None:
-            self._m.figure.f.canvas.mpl_disconnect(self._event_attached)
-
-        self.redraw()
-
-    def zoom_decorator(self, f):
-        def newzoom(event):
-            ret = f(event)
-            self.redraw()
-            return ret
-
-        return newzoom
-
-    def update_decorator(self, f):
-        def newupdate():
-            ret = f()
-            self.redraw()
-            return ret
-
-        return newupdate
+            self._m.BM.add_bg_artist(self._artist, layer)

--- a/eomaps/callbacks.py
+++ b/eomaps/callbacks.py
@@ -116,7 +116,7 @@ class _click_callbacks(object):
         val_precision=4,
         permanent=False,
         text=None,
-        layer=10,
+        zorder=10,
         **kwargs,
     ):
         """
@@ -152,11 +152,13 @@ class _click_callbacks(object):
                 >>>     return "the string to print"
 
             The default is None.
-        layer : int
-            The layer-level on which to draw the artist.
-            (First layer 0 is drawn, then layer 1 on top then layer 2 etc...)
-            The default is 10.
-        **kwargs
+        zorder : int or float
+            The zorder of the artist. (e.g. the drawing-order)
+            For details, have a look at:
+
+            - https://matplotlib.org/stable/gallery/misc/zorder_demo.html
+
+        kwargs
             kwargs passed to matplotlib.pyplot.annotate(). The default is:
 
             >>> dict(xytext=(20, 20),
@@ -250,8 +252,8 @@ class _click_callbacks(object):
                 else:
                     self.permanent_annotations.append(annotation)
 
-            if layer is not None:
-                self.m.BM.add_artist(annotation, layer=layer)
+            annotation.set_zorder(zorder)
+            self.m.BM.add_artist(annotation)
 
             annotation.set_visible(True)
             annotation.xy = pos
@@ -307,7 +309,7 @@ class _click_callbacks(object):
         buffer=1,
         permanent=True,
         n=20,
-        layer=10,
+        zorder=10,
         **kwargs,
     ):
         """
@@ -349,10 +351,11 @@ class _click_callbacks(object):
         n : int
             The number of points to calculate for the shape.
             The default is 20.
-        layer : int
-            The layer-level on which to draw the artist.
-            (First layer 0 is drawn, then layer 1 on top then layer 2 etc...)
-            The default is 10.
+        zorder : int or float
+            The zorder of the artist. (e.g. the drawing-order)
+            For details, have a look at:
+
+            - https://matplotlib.org/stable/gallery/misc/zorder_demo.html
         kwargs :
             kwargs passed to the matplotlib patch.
             (e.g. `facecolor`, `edgecolor`, `linewidth`, `alpha` etc.)
@@ -454,8 +457,8 @@ class _click_callbacks(object):
         else:
             self._temporary_artists.append(marker)
 
-        if layer is not None:
-            self.m.BM.add_artist(marker, layer)
+        marker.set_zorder(zorder)
+        self.m.BM.add_artist(marker)
 
         return marker
 
@@ -560,7 +563,6 @@ class _click_callbacks(object):
             marker = self.mark(
                 pos=((x0m + x1m) / 2, (y0m + y1m) / 2),
                 radius_crs="out",
-                layer=1,
                 shape="rectangles",
                 radius=(w / 2, h / 2),
                 permanent=False,
@@ -612,7 +614,6 @@ class _click_callbacks(object):
             marker = self.mark(
                 pos=pos,
                 radius_crs="out",
-                layer=1,
                 shape="rectangles",
                 radius=(w / 2, h / 2),
                 permanent=False,

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -2902,7 +2902,7 @@ class Maps(object):
             gdf = self._make_rect_poly(x0, y0, x1, y1, self.get_crs(crs), npts)
             self.add_gdf(gdf, **kwargs)
 
-    def add_logo(self, filepath=None, position="lr", size=0.12, pad=0.1):
+    def add_logo(self, filepath=None, position="lr", size=0.12, pad=0.1, layer="all"):
         """
         Add a small image (png, jpeg etc.) to the map whose position is dynamically
         updated if the plot is resized or zoomed.
@@ -2924,7 +2924,14 @@ class Maps(object):
             Padding between the axis-edge and the logo as a fraction of the logo-width.
             If a tuple is passed, (x-pad, y-pad)
             The default is 0.1.
+        layer : int, str or None
+            The name of the layer at which the logo should be visible.
+            If None, the layer of the Maps-object will be used.
+            The default is "all" (e.g. the logo is shown on all layers)
         """
+
+        if layer is None:
+            layer = self.layer
 
         if filepath is None:
             filepath = Path(__file__).parent / "logo.png"
@@ -2951,7 +2958,8 @@ class Maps(object):
         figax = self.figure.f.add_axes(**getpos(self.ax.get_position()))
         figax.set_navigate(False)
         figax.set_axis_off()
-        figax.imshow(im, aspect="equal")
+        art = figax.imshow(im, aspect="equal", zorder=999)
+        self.BM.add_bg_artist(art, layer)
 
         def setlim(*args, **kwargs):
             figax.set_position(getpos(self.ax.get_position())["rect"])

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -433,12 +433,26 @@ class Maps(object):
         self.parent._ignore_cb_events = False
 
         if newax:  # only if a new axis has been created
+            self._ax_xlims = (0, 0)
+            self._ax_ylims = (0, 0)
 
-            def lims_change(*args, **kwargs):
-                self.BM._refetch_bg = True
+            def xlims_change(*args, **kwargs):
+                if self._ax_xlims != args[0].get_xlim():
+                    print("x limchange", self.BM._refetch_bg)
+                    self.BM._refetch_bg = True
+                    # self.figure.f.stale = True
+                    self._ax_xlims = args[0].get_xlim()
 
-            self.figure.ax.callbacks.connect("xlim_changed", lims_change)
-            self.figure.ax.callbacks.connect("ylim_changed", lims_change)
+            # def ylims_change(*args, **kwargs):
+            #     if self._ax_ylims != args[0].get_ylim():
+            #         print("y limchange", self.BM._refetch_bg)
+            #         self.BM._refetch_bg = True
+            #         self._ax_ylims = args[0].get_ylim()
+
+            # do this only on xlims and NOT on ylims to avoid recursion
+            # (plot aspect ensures that y changes if x changes)
+            self.figure.ax.callbacks.connect("xlim_changed", xlims_change)
+            # self.figure.ax.callbacks.connect("ylim_changed", ylims_change)
 
         if newfig:  # only if a new figure has been initialized
             _ = self._draggable_axes

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -2160,7 +2160,7 @@ class Maps(object):
         # remove previously fetched backgrounds for the used layer
         if layer in self.BM._bg_layers and dynamic is False:
             del self.BM._bg_layers[layer]
-        self.BM._refetch_bg = True
+            # self.BM._refetch_bg = True
 
         if self.shape.name == "shade_raster":
             crs1 = CRS.from_user_input(self.data_specs.crs)
@@ -2422,7 +2422,7 @@ class Maps(object):
             # remove previously fetched backgrounds for the used layer
             if layer in self.BM._bg_layers and dynamic is False:
                 del self.BM._bg_layers[layer]
-            self.BM._refetch_bg = True
+                # self.BM._refetch_bg = True
 
             if self.data is None:
                 return

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -2081,7 +2081,11 @@ class Maps(object):
         )
 
         if lon is None or lat is None:
+            s._auto_position = auto_position
             lon, lat = s._get_autopos(auto_position)
+        else:
+            # don't auto-reposition if lon/lat has been provided
+            s._auto_position = None
 
         s._add_scalebar(lon, lat, azim)
         s._make_pickable()

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -477,12 +477,15 @@ class Maps(object):
 
         if newfig:
             # we only need to call show if a new figure has been created!
-            plt.show()
+            if plt.isinteractive():
+                # make sure to call show only if we use an interactive backend...
+                # (otherwise it will block subsequent code!)
+                plt.show()
 
     def _on_resize(self, event):
         # make sure the background is re-fetched if the canvas has been resized
-        # (required for peeking layers after the canvas has been resized)
-
+        # (required for peeking layers after the canvas has been resized
+        #  and for webagg and nbagg backends to correctly re-draw the layer)
         self.BM._refetch_bg = True
 
     def _on_close(self, event):

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -438,7 +438,6 @@ class Maps(object):
 
             def xlims_change(*args, **kwargs):
                 if self._ax_xlims != args[0].get_xlim():
-                    print("x limchange", self.BM._refetch_bg)
                     self.BM._refetch_bg = True
                     # self.figure.f.stale = True
                     self._ax_xlims = args[0].get_xlim()

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -3152,6 +3152,13 @@ class MapsGrid:
     def __init__(
         self,
         r=2,
+        c=2,
+        crs=None,
+        m_inits=None,
+        ax_inits=None,
+        figsize=None,
+        layer=0,
+        **kwargs,
     ):
 
         self._Maps = []
@@ -3180,6 +3187,7 @@ class MapsGrid:
                             crs=crsij,
                             gs_ax=self.gridspec[0, 0],
                             figsize=figsize,
+                            layer=layer,
                         )
                         self.parent = mij
                     else:
@@ -3187,6 +3195,7 @@ class MapsGrid:
                             crs=crsij,
                             parent=self.parent,
                             gs_ax=self.gridspec[i, j],
+                            layer=layer,
                         )
 
                     self._Maps.append(mij)
@@ -3215,12 +3224,18 @@ class MapsGrid:
 
                     if i == 0:
                         mi = Maps(
-                            crs=crs[key], gs_ax=self.gridspec[val], figsize=figsize
+                            crs=crs[key],
+                            gs_ax=self.gridspec[val],
+                            figsize=figsize,
+                            layer=layer,
                         )
                         self.parent = mi
                     else:
                         mi = Maps(
-                            crs=crs[key], parent=self.parent, gs_ax=self.gridspec[val]
+                            crs=crs[key],
+                            parent=self.parent,
+                            gs_ax=self.gridspec[val],
+                            layer=layer,
                         )
 
                     name = str(key)
@@ -3452,6 +3467,10 @@ class MapsGrid:
         """
         self.parent.join_limits(*self.children)
 
+    @wraps(Maps.redraw)
+    def redraw(self):
+        self.parent.redraw()
+
     @wraps(plt.savefig)
     def savefig(self, *args, **kwargs):
 
@@ -3460,3 +3479,8 @@ class MapsGrid:
         self.parent.BM._bg_layers = dict()
 
         self.f.savefig(*args, **kwargs)
+
+    @property
+    @wraps(Maps.util)
+    def util(self):
+        return self.parent.util

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -758,9 +758,11 @@ class BlitManager:
         # while we re-draw the artists
         cv.mpl_disconnect(self.cid)
         cv.draw()
+        self._bg_layers[layer] = cv.copy_from_bbox(bbox)
+        # blit here to avoid issues with the nbagg backend
+        self.update(clear=False, blit=True)
         self.cid = cv.mpl_connect("draw_event", self.on_draw)
 
-        self._bg_layers[layer] = cv.copy_from_bbox(bbox)
         self._refetch_bg = False
 
     def on_draw(self, event):
@@ -781,6 +783,7 @@ class BlitManager:
             # (they are cleared on clicks only)
             self.update(clear=False, blit=False)
         except Exception:
+            # we need to catch exceptions since QT does not like them...
             pass
 
     def add_artist(self, art, layer=0):
@@ -916,6 +919,7 @@ class BlitManager:
             If provided NO layer will be automatically updated!
             The default is None.
         """
+
         cv = self.canvas
         fig = cv.figure
 

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -354,7 +354,6 @@ class draggable_axes:
 
                     # self._m_picked.figure.ax_cb_plot.set_visible(vis)
                     self._ax_visible[self._m_picked.figure.ax_cb_plot] = vis
-                    print("hiding ax_cb_plot DONE")
 
                 elif key == "down":
                     # toggle ax_cb and make the ticks visible
@@ -887,10 +886,8 @@ class BlitManager:
             a.zorder -= overlay_zorder_bias
 
         self._refetch_bg = False
-        print("REFETCHED", layer, overlay_name)
 
     def on_draw(self, event):
-        print("draw")
         """Callback to register with 'draw_event'."""
         cv = self.canvas
         if event is not None:
@@ -1191,7 +1188,6 @@ class BlitManager:
         def action():
             name = self._get_overlay_name(layer, bg_layer=self.bg_layer)
 
-            print("THE NAME IS ", name)
             if self.bg_layer == layer:
                 return
 

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -810,7 +810,7 @@ class BlitManager:
         self._bg_layer = val
         # self.canvas.flush_events()
         self._clear_temp_artists("on_layer_change")
-        self.fetch_bg(self._bg_layer)
+        # self.fetch_bg(self._bg_layer)
 
     def fetch_bg(self, layer=None, bbox=None, overlay=None):
         # add this to the zorder of the overlay-artists prior to plotting

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -1151,8 +1151,7 @@ class BlitManager:
                 else:
                     layers = layer
 
-                for l in layers:
-                    self.fetch_bg(self._bg_layer, overlay=(name, layer))
+                self.fetch_bg(self._bg_layer, overlay=(name, layers))
 
                 self.fetch_bg(initial_layer)
                 self._m.show_layer(initial_layer)

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -1002,8 +1002,7 @@ class BlitManager:
                     layers = layer
 
                 for l in layers:
-                    self.fetch_bg(l, overlay=(name, layer))
-                    self._bg_layers[name] = self._bg_layers[l]
+                    self.fetch_bg(self._bg_layer, overlay=(name, layer))
 
                 self.fetch_bg(initial_layer)
                 self._m.show_layer(initial_layer)

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -757,7 +757,7 @@ class BlitManager:
         self._m = m
 
         self._bg = None
-        self._layers = defaultdict(list)
+        self._artists = defaultdict(list)
 
         self._bg_artists = defaultdict(list)
         self._bg_layers = dict()
@@ -912,7 +912,7 @@ class BlitManager:
             # we need to catch exceptions since QT does not like them...
             pass
 
-    def add_artist(self, art, layer=0):
+    def add_artist(self, art):
         """
         Add an artist to be managed.
 
@@ -926,13 +926,15 @@ class BlitManager:
         layer : bool
             The layer number
         """
+        layer = art.get_zorder()
+
         if art.figure != self.canvas.figure:
             raise RuntimeError
-        if art in self._layers[layer]:
+        if art in self._artists[layer]:
             return
         else:
             art.set_animated(True)
-            self._layers[layer].append(art)
+            self._artists[layer].append(art)
 
     def add_bg_artist(self, art, layer=0):
         """
@@ -976,14 +978,14 @@ class BlitManager:
 
     def remove_artist(self, art, layer=None):
         if layer is None:
-            for key, val in self._layers.items():
+            for key, val in self._artists.items():
                 if art in val:
                     art.set_animated(False)
                     val.remove(art)
         else:
-            if art in self._layers[layer]:
+            if art in self._artists[layer]:
                 art.set_animated(False)
-                self._layers[layer].remove(art)
+                self._artists[layer].remove(art)
 
     def _draw_animated(self, layers=None, artists=None):
         """
@@ -998,14 +1000,14 @@ class BlitManager:
 
         if layers is None and artists is None:
             # redraw all layers
-            for l in sorted(list(self._layers), key=lambda x: str(x)):
-                for a in self._layers[l]:
+            for l in sorted(list(self._artists)):
+                for a in self._artists[l]:
                     fig.draw_artist(a)
         else:
             if layers is not None:
                 # redraw artists from the selected layers
                 for l in layers:
-                    for a in self._layers[l]:
+                    for a in self._artists[l]:
                         fig.draw_artist(a)
             if artists is not None:
                 # redraw provided artists

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -631,7 +631,7 @@ class draggable_axes:
 
     def _undo_draggable(self):
         self._modifier_pressed = False
-        self.m._ignore_cb_events = True
+        self.m._ignore_cb_events = False
 
         print("EOmaps: Making axes interactive again")
         for ax, frameQ, spine_vis in zip(
@@ -649,8 +649,11 @@ class draggable_axes:
                 self.f.canvas.mpl_disconnect(cid)
 
         self.clear_annotations()
-        self.m.BM.fetch_bg()
+        # self.m.BM.fetch_bg()
+
+        self.m.BM._refetch_bg = True
         self.f.canvas.draw()
+        self.m.BM.update()
 
     def _make_draggable(self):
         # all ordinary callbacks will not execute if" self._modifier_pressed" is True!
@@ -660,7 +663,7 @@ class draggable_axes:
         self._frameon = [i.get_frame_on() for i in self.all_axes]
 
         self._modifier_pressed = True
-        self.m._ignore_cb_events = False
+        self.m._ignore_cb_events = True
         print("EOmaps: Making axis draggable")
 
         for ax in self.all_axes:

--- a/eomaps/scalebar.py
+++ b/eomaps/scalebar.py
@@ -553,7 +553,9 @@ class ScaleBar:
                 )
                 + self._m.figure.ax.transData
             )
-            self._m.BM.add_artist(self._artists[f"text_{i}"], layer=1)
+
+            self._artists[f"text_{i}"].set_zorder(1)
+            self._m.BM.add_artist(self._artists[f"text_{i}"])
 
     def _redraw_minitxt(self):
         # don't redraw if we haven't drawn anything yet
@@ -661,9 +663,12 @@ class ScaleBar:
         self._artists["scale"] = self._m.figure.ax.add_collection(coll, autolim=False)
 
         # -------------- make all artists animated
-        self._m.BM.add_artist(self._artists["scale"], layer=1)
-        # self._m.BM.add_artist(self._artists["text"], layer=1)
-        self._m.BM.add_artist(self._artists["patch"], layer=0)
+        self._artists["scale"].set_zorder(1)
+        self._artists["patch"].set_zorder(0)
+
+        self._m.BM.add_artist(self._artists["scale"])
+        # self._m.BM.add_artist(self._artists["text"])
+        self._m.BM.add_artist(self._artists["patch"])
 
         self._m.BM.update(artists=self._artists.values())
 

--- a/eomaps/scalebar.py
+++ b/eomaps/scalebar.py
@@ -279,7 +279,7 @@ class ScaleBar:
 
         if hasattr(self, "_lon") and hasattr(self, "_lat"):
             self.set_position()
-            self._m.BM.update()
+            self._m.BM.update(blit=False)
 
     def set_patch_props(self, offsets=None, **kwargs):
         """
@@ -317,7 +317,7 @@ class ScaleBar:
 
         if hasattr(self, "_lon") and hasattr(self, "_lat"):
             self.set_position()
-            self._m.BM.update()
+            self._m.BM.update(blit=False)
 
     def set_label_props(
         self, scale=None, rotation=None, every=None, offset=None, color=None, **kwargs
@@ -372,7 +372,7 @@ class ScaleBar:
 
         if hasattr(self, "_lon") and hasattr(self, "_lat"):
             self.set_position()
-            self._m.BM.update()
+            self._m.BM.update(blit=False)
 
     def _get_base_pts(self, lon, lat, azim, npts=None):
         if npts is None:
@@ -499,7 +499,7 @@ class ScaleBar:
         # arguments are only used for caching!
 
         # update here to make sure axis-transformations etc. are properly set
-        self._m.BM.update()
+        self._m.BM.update(blit=False)
 
         # the max. width of the texts
         _maxw = 0
@@ -619,8 +619,9 @@ class ScaleBar:
         assert (
             self._artists["scale"] is None
         ), "EOmaps: there is already a scalebar present!"
+
         # do this to make sure that the ax-transformations work as expected
-        self._m.BM.update()
+        self._m.BM.update(blit=False)
 
         self._lon = lon
         self._lat = lat
@@ -686,6 +687,7 @@ class ScaleBar:
             Indicator if the plot should be updated or not
             The default is True.
         """
+
         if lon is None:
             lon = self._lon
         if lat is None:
@@ -716,13 +718,14 @@ class ScaleBar:
         self._artists["patch"].set_verts([verts])
         self._artists["patch"].update(self._patch_props)
 
-        if self._m.cb.pick[self._picker_name].is_picked:
-            self._artists["patch"].set_edgecolor("r")
-            self._artists["patch"].set_linewidth(2)
-            self._artists["patch"].set_linestyle("-")
+        if self._picker_name:
+            if self._m.cb.pick[self._picker_name].is_picked:
+                self._artists["patch"].set_edgecolor("r")
+                self._artists["patch"].set_linewidth(2)
+                self._artists["patch"].set_linestyle("-")
 
         if update:
-            self._m.BM.update()
+            self._m.BM.update(blit=False)
 
     def _make_pickable(self):
         """
@@ -877,6 +880,7 @@ class ScaleBar:
     def _zoom_decorator(self, f):
         def newzoom(event):
             ret = f(event)
+
             # clear the cache to re-evaluate the text-width
             self.__class__._get_maxw.cache_clear()
             if self._autoscale is not None:

--- a/eomaps/utilities.py
+++ b/eomaps/utilities.py
@@ -152,7 +152,6 @@ class _layer_selector:
         self._selectors = []
 
     def _get_layers(self, layers=None):
-
         if layers is None:
             # get all (empty and non-empty) layers except the "all" layer
             layers = set((m.layer for m in self._m.parent._children))
@@ -253,6 +252,8 @@ class _layer_selector:
             # button update function returns a string of the layer object
             l = layers[int(val)]
             self._m.BM.bg_layer = l
+            self._m.BM.update(blit=False)
+            self._m.BM.canvas.draw_idle()
 
         s.on_clicked = update
         s.set_draggable(draggable, m=self._m)
@@ -262,7 +263,6 @@ class _layer_selector:
             s.leg.remove()
             if s in self._selectors:
                 self._selectors.remove(s)
-            self._m.BM.update()
 
         s.remove = remove
 
@@ -392,6 +392,7 @@ class _layer_selector:
             # button update function returns a string of the layer object
             l = layers[int(val)]
             self._m.BM.bg_layer = l
+            # self._m.show_layer(l)
 
         self._m.BM.add_artist(ax_slider)
 

--- a/eomaps/utilities.py
+++ b/eomaps/utilities.py
@@ -249,11 +249,23 @@ class _layer_selector:
         s = SelectorButtons(self._m.figure.f, layers, **kwargs)
 
         def update(val):
-            # button update function returns a string of the layer object
             l = layers[int(val)]
+
+            # make sure we re-fetch the artist states on a layer change during
+            # draggable-axes
+            drag = self._m.parent._draggable_axes
+            d = False
+            if drag._modifier_pressed:
+                drag._undo_draggable()
+                d = True
+
             self._m.BM.bg_layer = l
-            self._m.BM.update(blit=False)
-            self._m.BM.canvas.draw_idle()
+
+            if d:
+                drag._make_draggable()
+            else:
+                self._m.BM.update(blit=False)
+                self._m.BM.canvas.draw_idle()
 
         s.on_clicked = update
         s.set_draggable(draggable, m=self._m)
@@ -389,10 +401,21 @@ class _layer_selector:
         s.track.set_y(s.track.get_y() + h / 2)
 
         def update(val):
-            # button update function returns a string of the layer object
             l = layers[int(val)]
+
+            # make sure we re-fetch the artist states on a layer change during
+            # draggable-axes
+            drag = self._m.parent._draggable_axes
+            d = False
+            if drag._modifier_pressed:
+                drag._undo_draggable()
+                d = True
+
             self._m.BM.bg_layer = l
             # self._m.show_layer(l)
+
+            if d:
+                drag._make_draggable()
 
         self._m.BM.add_artist(ax_slider)
 

--- a/eomaps/utilities.py
+++ b/eomaps/utilities.py
@@ -278,7 +278,7 @@ class _layer_selector:
 
         s.remove = remove
 
-        self._m.BM.add_artist(s.leg, layer="all")
+        self._m.BM.add_artist(s.leg)
         # keep a reference to the buttons to make sure they stay interactive
         self._selectors.append(s)
 

--- a/eomaps/utilities.py
+++ b/eomaps/utilities.py
@@ -253,7 +253,6 @@ class _layer_selector:
             # button update function returns a string of the layer object
             l = layers[int(val)]
             self._m.BM.bg_layer = l
-            self._m.BM.update()
 
         s.on_clicked = update
         s.set_draggable(draggable, m=self._m)
@@ -267,7 +266,7 @@ class _layer_selector:
 
         s.remove = remove
 
-        self._m.BM.add_artist(s.leg)
+        self._m.BM.add_artist(s.leg, layer="all")
         # keep a reference to the buttons to make sure they stay interactive
         self._selectors.append(s)
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ try:
 except Exception:
     long_description = "A library to create interactive maps of geographical datasets."
 
-version = "3.2.1"
+version = "3.3"
 
 setup(
     name="EOmaps",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ try:
 except Exception:
     long_description = "A library to create interactive maps of geographical datasets."
 
-version = "3.2"
+version = "3.2.1"
 
 setup(
     name="EOmaps",

--- a/tests/example2.py
+++ b/tests/example2.py
@@ -11,24 +11,29 @@ data = pd.DataFrame(
 )
 data = data.sample(4000)  # take 4000 random datapoints from the dataset
 # ------------------------------------
-
+# initialize a grid of Maps objects
 mg = MapsGrid(
-    1, 3, crs=[4326, Maps.CRS.Stereographic(), 3035], figsize=(11, 5), bottom=0.15
-)  # initialize a grid of Maps objects
+    1,
+    3,
+    crs=[4326, Maps.CRS.Stereographic(), 3035],
+    figsize=(11, 5),
+    bottom=0.15,
+    layer="first layer",
+)
 # set the data on ALL maps-objects of the grid
 mg.set_data(data=data, xcoord="lon", ycoord="lat", in_crs=4326)
 
-# --------- set specs for the first axes
+# --------- set specs for the first axis
 mg.m_0_0.ax.set_title("epsg=4326")
 mg.m_0_0.set_classify_specs(scheme="EqualInterval", k=10)
 
-# --------- set specs for the second axes
+# --------- set specs for the second axis
 mg.m_0_1.ax.set_title("Stereographic")
 mg.m_0_1.set_shape.rectangles()
-mg.m_0_1.set_classify_specs(scheme="Quantiles", k=4)
+mg.m_0_1.set_classify_specs(scheme="Quantiles", k=8)
+mg.m_0_1.plot_map()
 
-# --------- set specs for the third axes
-
+# --------- set specs for the third axis
 mg.m_0_2.ax.set_extent(mg.m_0_2.crs_plot.area_of_use.bounds)
 
 mg.m_0_2.ax.set_title("epsg=3035")
@@ -41,30 +46,65 @@ mg.plot_map()
 mg.add_colorbar()
 
 # clip the ocean shape by the plot-extent to avoid re-projection issues
-mg.add_feature.preset.ocean(clip="extent")
+mg.add_feature.preset.ocean()
 mg.add_feature.preset.land()
-mg.add_feature.preset.coastline()
+mg.add_feature.preset.coastline(layer="all")  # add the coastline to all layers
 
-# --------- plot all maps and rotate the ticks of the colorbar
-for m in mg:
-    m.figure.ax_cb.tick_params(rotation=90, labelsize=8)
+# --------- add a new layer for the second axis
+# (simply re-plot the data with a different classification and plot-shape)
+
+# NOTE: this layer is not visible by default but it can be shown by clicking
+# on the layer-switcher utility buttons (bottom center of the figure)
+m2 = mg.m_0_1.new_layer(
+    layer="layer 2 for second axis", copy_data_specs=True, copy_plot_specs=True
+)
+m2.set_shape.delaunay_triangulation(mask_radius=max(m2.shape.radius) * 2)
+m2.set_classify_specs(scheme="Quantiles", k=4)
+m2.set_plot_specs(cmap="RdYlBu")
+m2.plot_map()
+m2.add_colorbar()
+
+
 # --------- add some callbacks to indicate the clicked data-point to all maps
 for m in mg:
     m.cb.pick.attach.mark(
-        fc="r", ec="none", buffer=1, permanent=True, shape=m.shape.name
+        fc="r",
+        ec="none",
+        buffer=1,
+        permanent=True,
     )
     m.cb.pick.attach.mark(
-        fc="none", ec="r", lw=1, buffer=5, permanent=True, shape=m.shape.name
+        fc="none",
+        ec="r",
+        lw=1,
+        buffer=5,
+        permanent=True,
     )
 
     m.cb.click.attach.mark(
-        fc="none", ec="k", lw=2, buffer=10, permanent=False, shape=m.shape.name
+        fc="none",
+        ec="k",
+        lw=2,
+        buffer=10,
+        permanent=False,
     )
     m.add_logo()
-# add a specific annotation-callback to the second map
-# (put it on a layer > 10 (the default for markers) so that it appears above the markers)
-mg.m_0_1.cb.pick.attach.annotate(layer=11, text="the closest point is here!")
+# add an annotation-callback to the second map
+mg.m_0_1.cb.pick.attach.annotate(text="the closest point is here!", zorder=99)
 
 # share click & pick-events between all Maps-objects of the MapsGrid
 mg.share_click_events()
 mg.share_pick_events()
+
+
+# --------- add a layer-selector widget
+mg.util.layer_selector(ncol=2, loc="lower center", draggable=False)
+
+# --------- rotate the ticks of the colorbars
+for m in mg:
+    m.figure.ax_cb.tick_params(rotation=90, labelsize=8)
+m2.figure.ax_cb.tick_params(rotation=90, labelsize=8)
+
+# trigger a final re-draw of all layers to make sure the manual
+# changes to the ticks are properly reflected in the cached layers.
+mg.redraw()

--- a/tests/example4.py
+++ b/tests/example4.py
@@ -158,7 +158,7 @@ def cb2(self, pos, ID, val, **kwargs):
 cid = m.cb.pick.attach(cb2, button=3)
 
 # add some static text
-txt = (
+infotext = (
     "Left-click: temporary annotations\n"
     + "Right-click: permanent annotations\n"
     + "Middle-click: clear permanent annotations"
@@ -167,7 +167,7 @@ txt = (
 _ = m.figure.f.text(
     0.66,
     0.92,
-    txt,
+    infotext,
     fontsize=10,
     horizontalalignment="left",
     verticalalignment="top",

--- a/tests/example5.py
+++ b/tests/example5.py
@@ -48,13 +48,13 @@ m2.shape.radius = (m2.shape.radius[0] * 2, m2.shape.radius[1])
 
 m2.plot_specs.cmap = "magma"
 m2.plot_map()
-
 # --------- add another layer with data that is dynamically updated if we click on the masked area
 m3 = m.new_layer(copy_classify_specs=False)
 m3.data_specs.data = data_OK.sample(1000)
 m3.set_shape.ellipses(radius=25000, radius_crs=3857)
 m3.set_plot_specs(cmap="gist_ncar")
 # plot the map and assign a "dynamic_layer_idx" to allow dynamic updates of the collection
+
 m3.plot_map(edgecolor="w", linewidth=0.25, layer=10, dynamic=True)
 
 # --------- define a callback that will change the position and data-values of the additional layer
@@ -142,6 +142,7 @@ m.add_marker(
     ls="--",
     lw=2,
 )
+
 m.add_annotation(
     ID=mark_id,
     text=(

--- a/tests/example6.py
+++ b/tests/example6.py
@@ -22,8 +22,8 @@ wms1.add_layer.vv()
 # ------------- LAYER 1
 # if you just want to add features, you can do it within the same Maps-object!
 # add OpenStreetMap on the currently invisible layer (1)
-wms2 = m.add_wms.OpenStreetMap.OSM_mundialis
-wms2.add_layer.OSM_WMS(layer="OSM")
+wms2 = m.add_wms.OpenStreetMap  # .OSM_mundialis
+wms2.add_layer.default(layer="OSM")
 
 # ------------- LAYER 2
 # create a connected maps-object and plot some data on a new layer (2)
@@ -31,15 +31,16 @@ m2 = m.new_layer(layer="data")
 m2.set_data(data=data.sample(5000), xcoord="lon", ycoord="lat", crs=4326)
 m2.set_shape.geod_circles(radius=20000)
 m2.plot_map()
-m2.add_wms.S1GBM.add_layer.vv()  # add S1GBM as background on layer 2 as well
-
 
 # ------------ CALLBACKS
 # on a left-click, show layer 1 in a rectangle (with a size of 20% of the axis)
-m.cb.click.attach.peek_layer(layer="OSM", how=(0.2, 0.2))
+m.cb.click.attach.peek_layer(layer=["data", "OSM"], how=(0.2, 0.2))
 
 # on a right-click, "swipe" layer (2) from the left
-m.cb.click.attach.peek_layer(layer="data", how="left", button=3)
+m.cb.click.attach.peek_layer(
+    layer=["data", "S1GBM_vv"], how="left", button=3, overlay=True
+)
+
 
 m.cb.keypress.attach.switch_layer(layer="S1GBM_vv", key="0")
 m.cb.keypress.attach.switch_layer(layer="OSM", key="1")

--- a/tests/example7.py
+++ b/tests/example7.py
@@ -41,7 +41,7 @@ mg.plot_map(alpha=0.75, ec=(1, 1, 1, 0.5), pick_distance=25)
 for m in mg:
     # attach a callback to highlite the rectangles
     m.cb.pick.attach.mark(
-        permanent=False, shape="rectangles", fc="none", ec="b", lw=2, layer=5
+        permanent=False, shape="rectangles", fc="none", ec="b", lw=2, zorder=5
     )
 
     # attach a callback to highlite the countries and indicate the names

--- a/tests/example8.py
+++ b/tests/example8.py
@@ -1,9 +1,13 @@
 # EOmaps example 8: Adding scalebars - what about distances?
 
 from eomaps import Maps
+import matplotlib.pyplot as plt
+
+plt.get_backend()
 
 m = Maps(figsize=(9, 5))
 m.add_feature.preset.ocean(ec="k", scale="110m")
+m.cb.click.attach.annotate()
 
 
 s1 = m.add_scalebar(

--- a/tests/example8.py
+++ b/tests/example8.py
@@ -5,9 +5,11 @@ from eomaps import Maps
 m = Maps(figsize=(9, 5))
 m.add_feature.preset.ocean(ec="k", scale="110m")
 
+
 s1 = m.add_scalebar(
     -11,
     -50,
+    -45,
     scale=500000,
     scale_props=dict(n=10, width=5, colors=("k", ".25", ".5", ".75", ".95")),
     patch_props=dict(offsets=(1, 1.4, 1, 1), fc=(0.7, 0.8, 0.3, 1)),
@@ -15,11 +17,11 @@ s1 = m.add_scalebar(
 )
 
 s2 = m.add_scalebar(
-    46,
-    53,
-    scale=500000,
+    50,
+    -20,
+    45,
     scale_props=dict(n=6, width=3, colors=("k", "r")),
-    patch_props=dict(fc="none", ec="r", lw=0.5, offsets=(1, 1, 1, 1)),
+    patch_props=dict(fc="none", ec="r", lw=0.5, offsets=(1, 1, 1, 2)),
     label_props=dict(rotation=45, weight="bold", family="Impact"),
 )
 
@@ -29,7 +31,7 @@ s3 = m.add_scalebar(
     0,
     scale=500000,
     scale_props=dict(n=6, width=3, colors=("w", "r")),
-    patch_props=dict(fc=".25", ec="k", lw=0.5, offsets=(1, 1, 1, 1)),
+    patch_props=dict(fc=".25", ec="k", lw=0.5, offsets=(1, 1, 1, 2)),
     label_props=dict(color="w", rotation=45, weight="bold", family="Impact"),
 )
 
@@ -40,5 +42,13 @@ s4.set_position(-140, -55, 0)
 s4.set_scale_props(scale=750000, n=10, width=4, colors=("k", "w"))
 s4.set_patch_props(fc="none", ec="none", offsets=(1, 1.6, 1, 1))
 s4.set_label_props(scale=1.5, offset=0.5, every=2, weight="bold", family="Courier New")
+
+# NOTE that the black-and-white scalebar is automatically re-scaled and re-positioned
+#      on zoom events (the default if you don't provide an explicit scale & position)!
+#      ... to manually override this behaviour, uncomment the following lines
+
+# s4._auto_position = None
+# s4._autoscale = None
+
 
 m.add_logo()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -130,7 +130,7 @@ class TestCallbacks(unittest.TestCase):
             arrowprops=dict(arrowstyle="fancy"),
         )
 
-        cid = m.cb.click.attach.annotate(text=text, layer=0, **props)
+        cid = m.cb.click.attach.annotate(text=text, **props)
         self.click_ax_center(m)
 
         # ---------- test as PICK callback
@@ -157,7 +157,7 @@ class TestCallbacks(unittest.TestCase):
             arrowprops=dict(arrowstyle="fancy"),
         )
 
-        m.cb.pick.attach.annotate(text=text, layer=0, **props)
+        m.cb.pick.attach.annotate(text=text, **props)
         self.click_ax_center(m)
 
         plt.close("all")
@@ -192,14 +192,13 @@ class TestCallbacks(unittest.TestCase):
             fc="none",
             ec="m",
             n=100,
-            layer=3,
             permanent=False,
         )
 
         self.click_ax_center(m)
 
         cid = m.cb.click.attach.mark(
-            fc=(1, 0, 0, 0.5), ec="k", n=100, layer=20, permanent=False, buffer=15
+            fc=(1, 0, 0, 0.5), ec="k", n=100, permanent=False, buffer=15
         )
 
         self.click_ax_center(m)
@@ -234,14 +233,13 @@ class TestCallbacks(unittest.TestCase):
             fc="none",
             ec="m",
             n=100,
-            layer=3,
             permanent=False,
         )
 
         self.click_ax_center(m)
 
         cid = m.cb.pick.attach.mark(
-            fc=(1, 0, 0, 0.5), ec="k", n=100, layer=20, permanent=False, buffer=15
+            fc=(1, 0, 0, 0.5), ec="k", n=100, permanent=False, buffer=15
         )
 
         self.click_ax_center(m)


### PR DESCRIPTION
A release with some nice new features and a lot of usability updates and fixes.
❗ note that there is a breaking change compared to <v3.2 (only affecting the ambiguous "layer" kwarg of dynamic artists (see 🌦️ changes below for details) )

### 🌳 NEW 
 (⭐: new feature, 🍃: new functionalities for existing features)
- ⭐ There's a new pre-defined WebMap service: `m.add_wms.GEBCO`  that provides nice underwater topography (https://www.gebco.net/)
- ⭐ Theres a new function `m.redraw()` that can be used to force a re-draw of the entire figure 
- ⭐ shortcuts for `mg.redraw` and `mg.util` have been added to `MapsGrid`
- 🍃 `m.add_wms. ... <layer>.set_extent_to_bbox()` now supports a new kwarg `shrink` which can be used to set the extent to a "shrinked" bbox (useful to avoid request-errors for tiles outside the bbox)
- 🍃 `m.add_colorbar`  can now be used to add **individual colorbars for different plot-layers** 
  (the colorbars will always reflect the currently displayed layer)
- 🍃the `peek_layer` callback can now be used to either view one (or more) layers or to **overlay** one (or more) layers on top of the current background layer.
- 🍃 some major improvements have been implemented for fetching WebTiles from xyz-TileServer links.
  - `m.add_wms.get_service` now supports using custom `wms`, `wmts`, `restAPI` or `xyz` services

### 🌦️ changes
- the ambiguous (and misleading) `layer` kwarg has finally been removed from dynamic artists. 
 (note this "layer" was NOT referring to the actual plot-layer but to the stacking of dynamic artists!)
   - `layer` now always refers to the background layer name and not to the stack-order of dynamic artists!
   -   ❗  the plot-order of multiple artists on the same layer is now determined by matplotlib's `zorder` property.
      - ❕ old: `m.cb.click.attach.mark(layer=5)`  ➡️  new: `m.cb.click.attach.mark(zorder=5)`
      - ❕ old: `m.cb.click.attach.annotate(layer=5)`  ➡️  new: `m.cb.click.attach.annotate(zorder=5)`
      - ❕ old: `m.BM.add_artist(art, layer=5)`  ➡️   new: `m.BM.add_artist(art)` + `art.set_zorder(5)`
   - all examples have been updated accordingly

### 🔨  fixes
- fix _onrelease() missing 1 required positional argument
- fix issues with `nbagg` and `ipympl` backends (e.g. jupyter notebooks)
- fix `plt.show` should only be called if we're in an interactive backend!
- fix some issues with the scalebar and colorbar
- re-work of `draggable_axes`
- fix maxzoom for stamen_watercolor layer