### PR TITLE
Merge for v3.4

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,7 +4,11 @@ name: pre-commit
 #  pull_request:
 #  push:
 #    branches: [master, dev]
-on: [pull_request]
+on:
+    push:
+    pull_request:
+    # to trigger workflow manually from actions-tab
+    workflow_dispatch:
 
 jobs:
   pre-commit:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,7 +5,6 @@ name: pre-commit
 #  push:
 #    branches: [master, dev]
 on:
-    push:
     pull_request:
     # to trigger workflow manually from actions-tab
     workflow_dispatch:

--- a/.github/workflows/testMaps.yml
+++ b/.github/workflows/testMaps.yml
@@ -1,7 +1,6 @@
 name: test_Maps
 
 on:
-   push:
    pull_request:
    # to trigger workflow manually from actions-tab
    workflow_dispatch:

--- a/.github/workflows/testMaps.yml
+++ b/.github/workflows/testMaps.yml
@@ -1,6 +1,10 @@
 name: test_Maps
 
-on: [push, pull_request]
+on:
+   push:
+   pull_request:
+   # to trigger workflow manually from actions-tab
+   workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/testMaps.yml
+++ b/.github/workflows/testMaps.yml
@@ -1,6 +1,6 @@
 name: test_Maps
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,6 @@ repos:
         args: ["--markdown-linebreak-ext=md"]
     -   id: mixed-line-ending
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     -   id: black

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,18 +13,21 @@
 .. code-block:: python
 
     from eomaps import Maps
-    m = Maps(crs=4326, figsize=(10, 5))
+    m = Maps(crs=4326, layer="first layer", figsize=(10, 5))
     m.add_feature.preset.coastline()
+
+- ``crs`` represents the projection used for plotting
+- ``layer`` represents the name of the layer associated with the Maps-object (see below)
+- all additional keyword arguments are forwarded to the creation of the matplotlib-figure
+  (e.g.: ``figsize``, ``frameon``, ``edgecolor`` etc).
 
 
 Possible ways for specifying the crs for plotting are:
 
-- if you provide an ``integer``, it is identified as an epsg-code.
+- If you provide an integer, it is identified as an epsg-code (e.g. ``4326``, ``3035``, etc.).
 - All other CRS usable for plotting are accessible via ``Maps.CRS``,
   e.g.: ``crs=Maps.CRS.Orthographic()`` or ``crs=Maps.CRS.Equi7Grid_projection("EU")``.
-
-Additional keyword arguments are forwarded to the creation of the matplotlib-figure
-(e.g.: ``figsize``, ``frameon``, ``edgecolor`` etc).
+  (``Maps.CRS`` is just an accessor for ``cartopy.crs``)
 
 ▤ Layers
 ++++++++
@@ -35,13 +38,14 @@ Additional keyword arguments are forwarded to the creation of the matplotlib-fig
 .. code-block:: python
 
     m = Maps()    # same as `m = Maps(layer=0)`
-    # to add a feature to all layers, use `m.all`
-    m.all.add_feature.preset.coastline()
 
     # create a new layer
     m2 = m.new_layer(layer="ocean")
     # the ocean will only be visible if the "ocean" layer is visible.
     m2.add_feature.preset.ocean()
+
+    # to add a feature to all layers, use `m.all`
+    m.all.add_feature.preset.coastline()
 
     # show the "ocean" layer
     m.show_layer("ocean")
@@ -50,7 +54,10 @@ Additional keyword arguments are forwarded to the creation of the matplotlib-fig
 - If you don't provide an explicit layer name, the new Maps-object will use the same layer as its parent!
   (you can have multiple ``Maps`` objects on the same layer!)
 
-To manually switch between layers, use ``m.show_layer("the layer name")``, call ``m2.show()`` or have a look at the :ref:`utility`.
+
+.. note::
+    Features, datasets, colormaps etc. added to a ``Maps`` object are only visible if the associated layer is visible!
+    To manually switch between layers, use ``m.show_layer("the layer name")``, call ``m2.show()`` or have a look at the :ref:`utility`.
 
 .. note::
 
@@ -1304,9 +1311,6 @@ Similar to ``Maps.from_file``, a new layer based on a file can be added to an ex
     new_layer_from_file.GeoTIFF
     new_layer_from_file.NetCDF
     new_layer_from_file.CSV
-
-
-
 
 
 🔸 Miscellaneous

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -64,8 +64,10 @@ Possible ways for specifying the crs for plotting are:
     There is one layer-name that has a special meaning... the ``"all"`` layer.
     Any callbacks, features or plots added to this layer will be **executed on all other layers** as well!
 
-    You can always add features and callbacks to the ``all`` layer via the shortcut ``m.all. ...``
-
+    You can add features and callbacks to the ``all`` layer via:
+    - using the shortcut ``m.all. ...``
+    - creating a dedicated ``Maps`` object via ``m_all = Maps(layer="all")`` or ``m_all = m.new_layer("all")``
+    - using the "layer" kwarg of functions e.g. ``m.plot_map(layer="all")``
 
 .. currentmodule:: eomaps
 

--- a/eomaps/_cb_container.py
+++ b/eomaps/_cb_container.py
@@ -6,7 +6,7 @@ from eomaps.callbacks import (
 )
 from types import SimpleNamespace
 
-from functools import update_wrapper, partial, wraps, lru_cache
+from functools import update_wrapper, partial, wraps
 from collections import defaultdict
 import matplotlib.pyplot as plt
 
@@ -1187,41 +1187,45 @@ class cb_container:
 
         self._methods = ["click", "keypress"]
 
-    @property
-    @lru_cache()
-    @wraps(cb_click_container)
-    def click(self):
-        return cb_click_container(
+        self._click = cb_click_container(
             m=self._m,
             cb_cls=click_callbacks,
             method="click",
         )
 
-    @property
-    @lru_cache()
-    @wraps(cb_pick_container)
-    def pick(self):
-        return cb_pick_container(
+        self._pick = cb_pick_container(
             m=self._m,
-            cb_cls=pick_callbacks,
+            cb_cls=click_callbacks,
             method="pick",
         )
 
-    @property
-    @lru_cache()
-    @wraps(keypress_container)
-    def keypress(self):
-        return keypress_container(
+        self._keypress = keypress_container(
             m=self._m,
-            cb_cls=keypress_callbacks,
+            cb_cls=click_callbacks,
             method="keypress",
         )
 
+        self._dynamic = dynamic_callbacks(m=self._m)
+
     @property
-    @lru_cache()
+    @wraps(cb_click_container)
+    def click(self):
+        return self._click
+
+    @property
+    @wraps(cb_pick_container)
+    def pick(self):
+        return self._pick
+
+    @property
+    @wraps(keypress_container)
+    def keypress(self):
+        return self._keypress
+
+    @property
     @wraps(dynamic_callbacks)
     def dynamic(self):
-        return dynamic_callbacks(m=self._m)
+        return self._dynamic
 
     def add_picker(self, name, artist, picker):
         """

--- a/eomaps/_cb_container.py
+++ b/eomaps/_cb_container.py
@@ -473,7 +473,6 @@ class cb_click_container(_click_container):
         return clickdict
 
     def _onclick(self, event):
-
         clickdict = self._get_clickdict(event)
 
         if event.dblclick:
@@ -720,6 +719,11 @@ class cb_pick_container(_click_container):
         self._add_pick_callback()
 
     def _default_picker(self, artist, event):
+
+        # make sure that objects are only picked if we are on the right layer
+        if self._m.layer != self._m.BM.bg_layer:
+            return False, None
+
         try:
             # if no pick-callback is attached, don't identify the picked point
             if len(self._m.cb.pick.get.cbs) == 0:
@@ -779,6 +783,11 @@ class cb_pick_container(_click_container):
         if event.artist is not self._artist:
             return
 
+        # only execute onpick if the correct layer is visible
+        # (relevant for forwarded callbacks)
+        if self._m.layer != self._m.BM.bg_layer:
+            return
+
         # don't execute callbacks if a toolbar-action is active
         if (
             self._m.figure.f.canvas.toolbar is not None
@@ -786,6 +795,7 @@ class cb_pick_container(_click_container):
             return
 
         clickdict = self._get_pickdict(event)
+
         if event.mouseevent.dblclick:
             cbs = self.get.cbs["double"]
         else:
@@ -815,6 +825,11 @@ class cb_pick_container(_click_container):
 
         def pickcb(event):
             try:
+
+                # make sure pickcb is only executed if we are on the right layer
+                if self._m.layer != self._m.BM.bg_layer:
+                    return
+
                 # check if we want to ignore callbacks
                 if self._m._ignore_cb_events:
                     return

--- a/eomaps/_cb_container.py
+++ b/eomaps/_cb_container.py
@@ -1195,7 +1195,7 @@ class cb_container:
 
         self._pick = cb_pick_container(
             m=self._m,
-            cb_cls=click_callbacks,
+            cb_cls=pick_callbacks,
             method="pick",
         )
 

--- a/eomaps/_cb_container.py
+++ b/eomaps/_cb_container.py
@@ -761,8 +761,11 @@ class cb_pick_container(_click_container):
         if ind is not None:
             if self._m.figure.coll is not None and event.artist is self._m.figure.coll:
                 clickdict = dict(
-                    pos=(self._m._props["x0"][ind], self._m._props["y0"][ind]),
-                    ID=self._m._props["ids"][ind],
+                    pos=(
+                        self._m._props["x0"].flat[ind],
+                        self._m._props["y0"].flat[ind],
+                    ),
+                    ID=self._m._props["ids"].flat[ind],
                     val=self._m._props["z_data"][ind],
                     ind=ind,
                     picker_name=self._picker_name,

--- a/eomaps/_cb_container.py
+++ b/eomaps/_cb_container.py
@@ -1201,7 +1201,7 @@ class cb_container:
 
         self._keypress = keypress_container(
             m=self._m,
-            cb_cls=click_callbacks,
+            cb_cls=keypress_callbacks,
             method="keypress",
         )
 

--- a/eomaps/_cb_container.py
+++ b/eomaps/_cb_container.py
@@ -457,7 +457,6 @@ class cb_click_container(_click_container):
         self._cid_button_press_event = None
         self._cid_button_release_event = None
         self._cid_motion_event = None
-        self._only = []
 
     def _init_cbs(self):
         if self._m.parent is self._m:
@@ -492,9 +491,7 @@ class cb_click_container(_click_container):
                     # maps-object is active
                     return
                 cb = bcbs[key]
-                if clickdict is not None and (
-                    len(self._only) == 0 or key in self._only
-                ):
+                if clickdict is not None:
                     cb(**clickdict)
 
     def _onrelease(self, event):

--- a/eomaps/_cb_container.py
+++ b/eomaps/_cb_container.py
@@ -398,10 +398,6 @@ class _click_container(_cb_container):
             else:
                 callback = callback.__get__(self._m)
 
-        # make sure multiple callbacks of the same funciton are only assigned
-        # if multiple assignments are properly handled
-        multi_cb_functions = ["mark", "annotate"]
-
         if double_click is True:
             btn_key = "double"
         elif double_click == "release":

--- a/eomaps/_cb_container.py
+++ b/eomaps/_cb_container.py
@@ -53,7 +53,9 @@ class _cb_container(object):
                 event = self._event
 
             for m in [*self._m.parent._children, self._m.parent]:
-                if event.inaxes is m.figure.ax:
+                # don't use "is" in here since Maps-children are proxies
+                # (and so are their attributes)!
+                if event.inaxes == m.figure.ax:
                     obj = self._getobj(m)
                     if obj is not None:
                         objs.append(obj)

--- a/eomaps/_containers.py
+++ b/eomaps/_containers.py
@@ -123,12 +123,7 @@ class map_objects(object):
         """
 
         if cb is None:
-            _, ax_cb, ax_cb_plot, orientation = [
-                self.cb_gridspec,
-                self.ax_cb,
-                self.ax_cb_plot,
-                self._m._orientation,
-            ]
+            _, ax_cb, ax_cb_plot, orientation, _ = self._m._colorbar
         else:
             _, ax_cb, ax_cb_plot, orientation, _ = cb
 

--- a/eomaps/_containers.py
+++ b/eomaps/_containers.py
@@ -127,7 +127,7 @@ class map_objects(object):
         else:
             _, ax_cb, ax_cb_plot, orientation, _ = cb
 
-        if orientation == "vertical":
+        if orientation == "horizontal":
             pcb = ax_cb.get_position()
             pcbp = ax_cb_plot.get_position()
             if pos is None:
@@ -145,7 +145,7 @@ class map_objects(object):
                 [pos[0], pos[1] + hcb, pos[2], hp],
             )
 
-        elif orientation == "horizontal":
+        elif orientation == "vertical":
             pcb = ax_cb.get_position()
             pcbp = ax_cb_plot.get_position()
             if pos is None:
@@ -164,6 +164,9 @@ class map_objects(object):
             )
         else:
             raise TypeError(f"EOmaps: '{orientation}' is not a valid orientation")
+
+        # re-fetch the background layer to make changes visible
+        self._m.BM.fetch_bg(self._m.layer)
 
 
 class data_specs(object):

--- a/eomaps/_containers.py
+++ b/eomaps/_containers.py
@@ -123,9 +123,9 @@ class map_objects(object):
         """
 
         if cb is None:
-            _, ax_cb, ax_cb_plot, orientation, _ = self._m._colorbar
+            _, _, ax_cb, ax_cb_plot, orientation, _ = self._m._colorbar
         else:
-            _, ax_cb, ax_cb_plot, orientation, _ = cb
+            _, _, ax_cb, ax_cb_plot, orientation, _ = cb
 
         if orientation == "horizontal":
             pcb = ax_cb.get_position()

--- a/eomaps/_shapes.py
+++ b/eomaps/_shapes.py
@@ -137,8 +137,8 @@ class shapes(object):
             in_tree = cKDTree(
                 np.stack(
                     [
-                        m._props["xorig"][: m.set_shape.radius_estimation_range],
-                        m._props["yorig"][: m.set_shape.radius_estimation_range],
+                        m._props["xorig"].flat[: m.set_shape.radius_estimation_range],
+                        m._props["yorig"].flat[: m.set_shape.radius_estimation_range],
                     ],
                     axis=1,
                 ),
@@ -153,8 +153,8 @@ class shapes(object):
             tree = cKDTree(
                 np.stack(
                     [
-                        m._props["x0"][: m.set_shape.radius_estimation_range],
-                        m._props["y0"][: m.set_shape.radius_estimation_range],
+                        m._props["x0"].flat[: m.set_shape.radius_estimation_range],
+                        m._props["y0"].flat[: m.set_shape.radius_estimation_range],
                     ],
                     axis=1,
                 ),

--- a/eomaps/_shapes.py
+++ b/eomaps/_shapes.py
@@ -323,7 +323,6 @@ class shapes(object):
         def get_coll(self, x, y, crs, **kwargs):
 
             xs, ys, mask = self._get_geod_circle_points(x, y, crs, self.radius, self.n)
-
             # special treatment of array input to properly mask values
             array = kwargs.pop("array", None)
 
@@ -351,6 +350,7 @@ class shapes(object):
                 array=array,
                 **kwargs,
             )
+
             return coll
 
     class _ellipses(object):

--- a/eomaps/_webmap.py
+++ b/eomaps/_webmap.py
@@ -297,7 +297,7 @@ class _wmts_layer(_WebMap_layer):
             else:
                 self._layer = layer
 
-            if self._m.BM.bg_layer == self._layer:
+            if self._layer == "all" or self._m.BM.bg_layer == self._layer:
                 # add the layer immediately if the layer is already active
                 self._do_add_layer(self._m, self._layer)
             else:
@@ -348,7 +348,7 @@ class _wms_layer(_WebMap_layer):
             else:
                 self._layer = layer
 
-            if m.BM.bg_layer == self._layer:
+            if self._layer == "all" or m.BM.bg_layer == self._layer:
                 # add the layer immediately if the layer is already active
                 self._do_add_layer(m, self._layer)
             else:
@@ -928,7 +928,7 @@ class _xyz_tile_service:
             )
             self._kwargs.update(kwargs)
 
-            if self._m.BM.bg_layer == self._layer:
+            if self._layer == "all" or self._m.BM.bg_layer == self._layer:
                 # add the layer immediately if the layer is already active
                 self._do_add_layer(self._m, self._layer)
             else:

--- a/eomaps/callbacks.py
+++ b/eomaps/callbacks.py
@@ -190,7 +190,10 @@ class _click_callbacks(object):
             if ID is not None and self.m.data is not None:
                 x, y = [
                     np.format_float_positional(i, trim="-", precision=pos_precision)
-                    for i in (self.m._props["xorig"][ind], self.m._props["yorig"][ind])
+                    for i in (
+                        self.m._props["xorig"].flat[ind],
+                        self.m._props["yorig"].flat[ind],
+                    )
                 ]
                 x0, y0 = [
                     np.format_float_positional(i, trim="-", precision=pos_precision)

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -3049,7 +3049,7 @@ class Maps(object):
         # remember colorbar for later (so that we can update its position etc.)
         self._colorbar = [layer, cbgs, ax_cb, ax_cb_plot, orientation, cb]
 
-        return [cbgs, ax_cb, ax_cb_plot, orientation, cb]
+        return [layer, cbgs, ax_cb, ax_cb_plot, orientation, cb]
 
     def indicate_masked_points(self, radius=1.0, **kwargs):
         """

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -2484,13 +2484,30 @@ class Maps(object):
         # in case 2D data and 1D coordinate arrays are provided, use a meshgrid
         # to identify the coordinates
         if n_coord_shape == 1 and len(props["z_data"].shape) == 2:
+
             props["x0"], props["y0"] = [
-                np.ravel(i) for i in np.meshgrid(props["x0"], props["y0"], copy=False)
+                i
+                for i in np.broadcast_arrays(
+                    *np.meshgrid(props["x0"], props["y0"], copy=False, sparse=True)
+                )
             ]
+
             props["xorig"], props["yorig"] = [
-                np.ravel(i)
-                for i in np.meshgrid(props["xorig"], props["yorig"], copy=False)
+                i
+                for i in np.broadcast_arrays(
+                    *np.meshgrid(
+                        props["xorig"], props["yorig"], copy=False, sparse=True
+                    )
+                )
             ]
+
+            # props["x0"], props["y0"] = [
+            #     np.ravel(i) for i in np.meshgrid(props["x0"], props["y0"], copy=False)
+            # ]
+            # props["xorig"], props["yorig"] = [
+            #     np.ravel(i)
+            #     for i in np.meshgrid(props["xorig"], props["yorig"], copy=False)
+            # ]
 
             # transpose since 1D coordinates are expected to be provided as (y, x)
             # and NOT as (x, y)
@@ -2614,7 +2631,9 @@ class Maps(object):
             else:
                 args = dict(array=props["z_data"], cmap=cbcmap, norm=norm, **kwargs)
 
-            coll = self.shape.get_coll(props["xorig"], props["yorig"], "in", **args)
+            coll = self.shape.get_coll(
+                props["xorig"].ravel(), props["yorig"].ravel(), "in", **args
+            )
 
             coll.set_clim(vmin, vmax)
             ax.add_collection(coll)

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -368,6 +368,14 @@ class Maps(object):
 
     @property
     def all(self):
+        """
+        Get a Maps-object on the "all" layer.
+
+        Use it just as any other Maps-object. (It's the same as Maps(layer="all"))
+
+        >>> m.all.cb.click.attach.annotate()
+
+        """
         if not hasattr(self.parent, "_all"):
             self.parent._all = self.parent.new_layer("all")
         return self.parent._all

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -332,7 +332,6 @@ class Maps(object):
 
         """
         # remove the xlim-callback since it contains a reference to self
-        print("cleanup")
         if hasattr(self, "_cid_xlim"):
             self.ax.callbacks.disconnect(self._cid_xlim)
             del self._cid_xlim

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -3056,7 +3056,7 @@ class Maps(object):
             gdf = self._make_rect_poly(x0, y0, x1, y1, self.get_crs(crs), npts)
             self.add_gdf(gdf, **kwargs)
 
-    def add_logo(self, filepath=None, position="lr", size=0.12, pad=0.1, layer="all"):
+    def add_logo(self, filepath=None, position="lr", size=0.12, pad=0.1):
         """
         Add a small image (png, jpeg etc.) to the map whose position is dynamically
         updated if the plot is resized or zoomed.
@@ -3078,14 +3078,7 @@ class Maps(object):
             Padding between the axis-edge and the logo as a fraction of the logo-width.
             If a tuple is passed, (x-pad, y-pad)
             The default is 0.1.
-        layer : int, str or None
-            The name of the layer at which the logo should be visible.
-            If None, the layer of the Maps-object will be used.
-            The default is "all" (e.g. the logo is shown on all layers)
         """
-
-        if layer is None:
-            layer = self.layer
 
         if filepath is None:
             filepath = Path(__file__).parent / "logo.png"

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -582,16 +582,22 @@ class Maps(object):
             if hasattr(m, "_props"):
                 m._props.clear()
                 del m._props
+
             if hasattr(m, "tree"):
                 del m.tree
+
             if hasattr(m.figure, "coll"):
                 del m.figure.coll
 
             m.data_specs.delete()
+            m.cleanup()
 
         # delete the tempfolder containing the memmaps
         if hasattr(self.parent, "_tmpfolder"):
             self.parent._tmpfolder.cleanup()
+
+        # run garbage-collection to immediately free memory
+        gc.collect
 
     @property
     def _ignore_cb_events(self):

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -334,13 +334,16 @@ class Maps(object):
         print("cleanup")
         if hasattr(self, "_cid_xlim"):
             self.ax.callbacks.disconnect(self._cid_xlim)
+            del self._cid_xlim
 
         # disconnect all callbacks from attached logos
         for cid in self._logo_cids:
             self.figure.f.canvas.mpl_disconnect(cid)
+            self._logo_cids.clear()
 
         # disconnect all click, pick and keypress callbacks
         self.cb._reset_cids()
+
         # call all additional cleanup functions
         for f in self._cleanup_functions:
             f()

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -2261,7 +2261,10 @@ class Maps(object):
             vmax = np.nanmax(props["z_data"])
 
         # clip the data to properly account for vmin and vmax
-        props["z_data"] = props["z_data"].clip(vmin, vmax)
+        # (do this only if we don't intend to use the full dataset!)
+        if self.plot_specs["vmin"] or self.plot_specs["vmax"]:
+            props["z_data"] = props["z_data"].clip(vmin, vmax)
+
         if verbose:
             print("EOmaps: Classifying...")
 
@@ -2583,7 +2586,9 @@ class Maps(object):
                 vmax = np.nanmax(props["z_data"])
 
             # clip the data to properly account for vmin and vmax
-            props["z_data"] = props["z_data"].clip(vmin, vmax)
+            # (do this only if we don't intend to use the full dataset!)
+            if self.plot_specs["vmin"] or self.plot_specs["vmax"]:
+                props["z_data"] = props["z_data"].clip(vmin, vmax)
 
             # ---------------------- classify the data
             cbcmap, norm, bins, classified = self._classify_data(

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -2182,16 +2182,9 @@ class Maps(object):
         patch_props=None,
         label_props=None,
     ):
-        # TODO temporary fix to make scalebar layer-independent
-        # (e.g. always attach it to a Maps-object at the "all" layer)
-        l_iter = (i for i in [self.parent, *self.parent._children] if i.layer == "all")
-        try:
-            s_m = next(l_iter)
-        except StopIteration:
-            s_m = self.new_layer("all")
 
         s = ScaleBar(
-            m=s_m,
+            m=self,
             preset=preset,
             scale=scale,
             autoscale_fraction=autoscale_fraction,

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -2810,7 +2810,11 @@ class Maps(object):
         """
         Add a colorbar to an existing figure.
 
-        (NOTE: the preferred way is to use `plot_map(colorbar=True)` instead!)
+        The colorbar always represents the data of the associated Maps-object
+        that was assigned in the last call to `m.plot_map()`.
+
+        By default, the colorbar will only be visible on the layer of the associated
+        Maps-object (you can override this by providing an explicit "layer"-name).
 
         To change the position of the colorbar, use:
 
@@ -2853,6 +2857,11 @@ class Maps(object):
             The padding between the colorbar and the parent axes (as fraction of the
             plot-height (if "horizontal") or plot-width (if "vertical")
             The default is (0.05, 0.1, 0.1, 0.05)
+        layer : int, str or None, optional
+            The layer to put the colorbar on.
+            To make the colorbar visible on all layers, use `layer="all"`
+            If None, the layer of the associated Maps-object is used.
+            The default is None.
         log : bool, optional
             Indicator if the y-axis of the plot should be logarithmic or not.
             The default is False
@@ -3024,7 +3033,7 @@ class Maps(object):
         )
 
         # hide the colorbar if it is not added to the currently visible layer
-        if layer != self.BM._bg_layer:
+        if layer not in [self.BM._bg_layer, "all"]:
             ax_cb.set_visible(False)
             ax_cb_plot.set_visible(False)
             m.BM._hidden_axes.add(ax_cb)
@@ -3038,7 +3047,7 @@ class Maps(object):
         self.BM.add_bg_artist(self._ax_cb_plot, layer)
 
         # remember colorbar for later (so that we can update its position etc.)
-        self._colorbar = [cbgs, ax_cb, ax_cb_plot, orientation, cb]
+        self._colorbar = [layer, cbgs, ax_cb, ax_cb_plot, orientation, cb]
 
         return [cbgs, ax_cb, ax_cb_plot, orientation, cb]
 

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -2882,6 +2882,13 @@ class Maps(object):
 
         """
 
+        if hasattr(self, "_colorbar"):
+            print(
+                "EOmaps: A colorbar already exists for this Maps-object!\n"
+                + "...use a new layer if you want multiple colorbars!"
+            )
+            return
+
         if layer is None:
             layer = self.layer
 

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -3034,6 +3034,9 @@ class Maps(object):
         self.BM.add_bg_artist(self._ax_cb, layer)
         self.BM.add_bg_artist(self._ax_cb_plot, layer)
 
+        # remember colorbar for later (so that we can update its position etc.)
+        self._colorbar = [cbgs, ax_cb, ax_cb_plot, orientation, cb]
+
         return [cbgs, ax_cb, ax_cb_plot, orientation, cb]
 
     def indicate_masked_points(self, radius=1.0, **kwargs):

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -358,6 +358,14 @@ class Maps(object):
     from_file = from_file
     read_file = read_file
 
+    def show(self):
+        """
+        Make the layer of this `Maps`-object visible.
+        (just a shortcut for `m.show_layer(m.layer)`)
+        """
+
+        self.show_layer(self.layer)
+
     @property
     def ax(self):
         return self._ax

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -311,6 +311,7 @@ class Maps(object):
 
     def __exit__(self, type, value, traceback):
         self.cleanup()
+        gc.collect()
 
     @staticmethod
     def _proxy(obj):

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -113,11 +113,6 @@ class Maps(object):
 
         Note: Instead of specifying explicit axes, you might want to have a
         look at `eomaps.MapsGrid` objects!
-
-    orientation : str, optional
-        Indicator if the colorbar should be plotted right of the map
-        ("horizontal") or below the map ("vertical"). The default is "vertical"
-
     f : matplotlib.Figure, optional
         Explicitly specify the matplotlib figure instance to use.
         (ONLY useful if you want to add a map to an already existing figure!)
@@ -196,7 +191,6 @@ class Maps(object):
         crs=None,
         parent=None,
         layer=0,
-        orientation="vertical",
         f=None,
         gs_ax=None,
         preferred_wms_service="wms",
@@ -209,7 +203,6 @@ class Maps(object):
             ), "You cannot specify the figure for connected Maps-objects!"
 
         self._f = f
-        self._orientation = orientation
         self._ax = gs_ax
         self._parent = None
 
@@ -217,7 +210,6 @@ class Maps(object):
         self._children = set()  # weakref.WeakSet()
 
         self.parent = parent  # invoke the setter!
-        self._orientation = "vertical"
         self.layer = layer
 
         # preferred way of accessing WMS services (used in the WMS container)
@@ -1290,7 +1282,7 @@ class Maps(object):
         vmax=None,
         tick_precision=3,
         density=False,
-        orientation=None,
+        orientation="vertical",
         log=False,
     ):
 
@@ -1323,9 +1315,6 @@ class Maps(object):
             tick_precision = self.plot_specs["tick_precision"]
         if density is None:
             density = self.plot_specs["density"]
-
-        if orientation is None:
-            orientation = self._orientation
 
         if orientation == "horizontal":
             cb_orientation = "vertical"

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -1265,9 +1265,6 @@ class Maps(object):
         if ax_cb_plot is None:
             ax_cb_plot = self.figure.ax_cb_plot
 
-        if log:
-            ax_cb_plot.set_xscale("log")
-
         if z_data is None:
             z_data = self._props["z_data"]
         z_data = z_data.ravel()
@@ -1298,8 +1295,15 @@ class Maps(object):
 
         if orientation == "horizontal":
             cb_orientation = "vertical"
+
+            if log:
+                ax_cb_plot.set_xscale("log")
+
         elif orientation == "vertical":
             cb_orientation = "horizontal"
+
+            if log:
+                ax_cb_plot.set_yscale("log")
 
         if histbins == "bins":
             assert (
@@ -1469,6 +1473,8 @@ class Maps(object):
             ot = ax_cb.yaxis.get_offset_text()
             ot.set_horizontalalignment("center")
             ot.set_position((1, 0))
+
+        ax_cb.autoscale()
 
         return cb
 

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -102,6 +102,9 @@ class Maps(object):
     layer : int or str, optional
         The name of the plot-layer assigned to this Maps-object.
         The default is 0.
+
+    Other Parameters:
+    -----------------
     parent : eomaps.Maps
         The parent Maps-object to use.
         Any maps-objects that share the same figure must be connected

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -99,6 +99,9 @@ class Maps(object):
         A list for easy-accses is available as `Maps.CRS`
 
         The default is 4326.
+    layer : int or str, optional
+        The name of the plot-layer assigned to this Maps-object.
+        The default is 0.
     parent : eomaps.Maps
         The parent Maps-object to use.
         Any maps-objects that share the same figure must be connected
@@ -208,9 +211,9 @@ class Maps(object):
 
         self._BM = None
         self._children = set()  # weakref.WeakSet()
+        self._layer = layer
 
         self.parent = parent  # invoke the setter!
-        self.layer = layer
 
         # preferred way of accessing WMS services (used in the WMS container)
         assert preferred_wms_service in [
@@ -361,6 +364,13 @@ class Maps(object):
 
     from_file = from_file
     read_file = read_file
+
+    @property
+    def layer(self):
+        """
+        The layer-name associated with this Maps-object.
+        """
+        return self._layer
 
     @property
     def all(self):

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -324,12 +324,16 @@ class Maps(object):
 
     def cleanup(self):
         """
-        Cleanup all references to the object so that it can be deleted.
+        Cleanup all references to the object so that it can be savely deleted.
+        (primarily used internally to clear objects if the figure is closed)
 
-        Returns
-        -------
-        None.
+        Note
+        ----
+        Executing this function will remove ALL attached callbacks
+        and delete all assigned datasets & pre-computed values.
 
+        ONLY execute this if you do not need to do anything with the layer
+        (except for looking at it)
         """
         # remove the xlim-callback since it contains a reference to self
         if hasattr(self, "_cid_xlim"):

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -2672,11 +2672,16 @@ class Maps(object):
 
             The default is True
         memmap : bool or None
-            Indicator if memory-mapping should be use to save memory for very
-            large datasets.
+            Indicator if memory-mapping should be use to save memory by storing
+            intermediate datasets (e.g. projected coordinates, indexes & the data)
+            in a temporary folder on disc rather than keeping everything in memory.
+            This will cause a slight decrease when identifying clicked points but it
+            provides a major reduction in memory-usage for very large datasets.
 
-            If None: memory-mapping is only used if "shade_raster" or "shade_points"
+            - If None: memory-mapping is only used if "shade_raster" or "shade_points"
             is used as plot-shape.
+            - if True: memory-mapping is used
+            - if False: memory-mapping is disabled
 
             The default is None.
 

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -276,6 +276,7 @@ class Maps(object):
         self._init_figure(gs_ax=gs_ax, plot_crs=crs, **kwargs)
         self._utilities = utilities(weakref.proxy(self))
         self._wms_container = wms_container(weakref.proxy(self))
+        self._new_layer_from_file = new_layer_from_file(weakref.proxy(self))
 
         self._shapes = shapes(weakref.proxy(self))
         self.set_shape.ellipses()
@@ -378,9 +379,8 @@ class Maps(object):
 
     @property
     @wraps(new_layer_from_file)
-    @lru_cache()
     def new_layer_from_file(self):
-        return new_layer_from_file(self)
+        return self._new_layer_from_file
 
     def new_layer(
         self,

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -371,7 +371,7 @@ class Maps(object):
         """
         Get a Maps-object on the "all" layer.
 
-        Use it just as any other Maps-object. (It's the same as Maps(layer="all"))
+        Use it just as any other Maps-object. (It's the same as `Maps(layer="all")`)
 
         >>> m.all.cb.click.attach.annotate()
 

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -2688,7 +2688,7 @@ class Maps(object):
         layer=None,
         dynamic=False,
         set_extent=True,
-        memmap=None,
+        memmap=False,
         **kwargs,
     ):
         """
@@ -2731,13 +2731,13 @@ class Maps(object):
             - if False: The plot-extent is kept as-is
 
             The default is True
-        memmap : bool, str, pathlib.Path or None
-            Indicator if memory-mapping should be use to save memory by storing
-            intermediate datasets (e.g. projected coordinates, indexes & the data)
-            in a temporary folder on disc rather than keeping everything in memory.
+        memmap : bool, str or pathlib.Path
+            Use memory-mapping to save some memory by storing intermediate datasets
+            (e.g. projected coordinates, indexes & the data) in a temporary folder on
+            disc rather than keeping everything in memory.
             This causes a slight performance penalty when identifying clicked points but
-            it provides a major reduction in memory-usage for very large datasets
-            (or if you want a large number of interactive layers).
+            it can provide a reduction in memory-usage for very large datasets
+            (or for a very large number of interactive layers).
 
             - If None: memory-mapping is only used if "shade_raster" or "shade_points"
               is used as plot-shape.
@@ -2751,7 +2751,7 @@ class Maps(object):
 
             The location of the tempfolder is accessible via `m._tempfolder`
 
-            The default is None.
+            The default is False.
 
         kwargs
             kwargs passed to the initialization of the matpltolib collection
@@ -2771,8 +2771,6 @@ class Maps(object):
                 set_extent=set_extent,
                 **kwargs,
             )
-            if memmap is None:
-                memmap = True
         else:
             self._plot_map(
                 pick_distance=pick_distance,

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -340,7 +340,6 @@ class Maps(object):
 
         # disconnect all click, pick and keypress callbacks
         self.cb._reset_cids()
-
         # call all additional cleanup functions
         for f in self._cleanup_functions:
             f()
@@ -432,19 +431,16 @@ class Maps(object):
         return m
 
     @property
-    # @lru_cache()
     @wraps(cb_container)
     def cb(self):
         return self._cb
 
     @property
-    # @lru_cache()
     @wraps(utilities)
     def util(self):
         return self._utilities
 
     @property
-    # @lru_cache()
     @wraps(map_objects)
     def figure(self):
         return self._figure
@@ -763,7 +759,6 @@ class Maps(object):
         self.data_specs.data = val
 
     @property
-    # @lru_cache()
     @wraps(shapes)
     def set_shape(self):
         return self._shapes
@@ -980,7 +975,6 @@ class Maps(object):
         return x, y
 
     @property
-    # @lru_cache()
     def crs_plot(self):
         """
         The crs used for plotting.
@@ -2195,7 +2189,6 @@ class Maps(object):
 
         @property
         @wraps(wms_container)
-        # @lru_cache()
         def add_wms(self):
             return self._wms_container
 

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -214,7 +214,7 @@ class Maps(object):
         self._parent = None
 
         self._BM = None
-        self._children = weakref.WeakSet()
+        self._children = set()  # weakref.WeakSet()
 
         self.parent = parent  # invoke the setter!
         self._orientation = "vertical"
@@ -349,6 +349,10 @@ class Maps(object):
         for f in self._cleanup_functions:
             f()
         self._cleanup_functions.clear()
+
+        # remove the children from the parent Maps object
+        if self in self.parent._children:
+            self.parent._children.remove(self)
 
     def _check_gpd(self):
         # raise an error if geopandas is not found

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from pathlib import Path
 import weakref
 from tempfile import TemporaryDirectory, TemporaryFile
+import gc
 
 import numpy as np
 

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -2442,7 +2442,7 @@ class Maps(object):
 
         if pick_distance is not None:
             # self.tree = cKDTree(np.stack([props["x0"], props["y0"]], axis=1))
-            self.tree = searchtree(m=self, pick_distance=pick_distance)
+            self.tree = searchtree(m=self._proxy(self), pick_distance=pick_distance)
 
             self.cb.pick._set_artist(coll)
             self.cb.pick._init_cbs()
@@ -2459,6 +2459,7 @@ class Maps(object):
 
     @staticmethod
     def _1Dprops(props):
+
         # convert all arrays in props to a proper 1D representation that will be used
         # to index and identify points
 
@@ -2616,7 +2617,7 @@ class Maps(object):
             self.figure.coll = coll
 
             if pick_distance is not None:
-                self.tree = searchtree(m=self, pick_distance=pick_distance)
+                self.tree = searchtree(m=self._proxy(self), pick_distance=pick_distance)
 
                 self.cb.pick._set_artist(coll)
                 self.cb.pick._init_cbs()

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -194,7 +194,7 @@ class Maps(object):
         self,
         crs=None,
         parent=None,
-        layer="all",
+        layer=0,
         orientation="vertical",
         f=None,
         gs_ax=None,
@@ -357,6 +357,12 @@ class Maps(object):
 
     from_file = from_file
     read_file = read_file
+
+    @property
+    def all(self):
+        if not hasattr(self.parent, "_all"):
+            self.parent._all = self.parent.new_layer("all")
+        return self.parent._all
 
     def show(self):
         """
@@ -3364,7 +3370,7 @@ class MapsGrid:
         m_inits=None,
         ax_inits=None,
         figsize=None,
-        layer="all",
+        layer=0,
         **kwargs,
     ):
 

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -3180,7 +3180,7 @@ class Maps(object):
         im = mpl.image.imread(filepath)
 
         def getpos(pos):
-            s = pos.width * size
+            s = size
             if isinstance(pad, tuple):
                 pwx, pwy = (s * pad[0], s * pad[1])
             else:

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -340,7 +340,7 @@ class Maps(object):
         # disconnect all callbacks from attached logos
         for cid in self._logo_cids:
             self.figure.f.canvas.mpl_disconnect(cid)
-            self._logo_cids.clear()
+        self._logo_cids.clear()
 
         # disconnect all click, pick and keypress callbacks
         self.cb._reset_cids()

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -795,6 +795,18 @@ class BlitManager:
     def canvas(self):
         return self._m.figure.f.canvas
 
+    def _do_on_layer_change(self, layer):
+        # general callbacks executed on any layer change
+        if len(self._on_layer_change) > 0:
+            for action in self._on_layer_change:
+                action(self._m, layer)
+
+        # individual callables executed if a specific layer is activated
+        activate_action = self._on_layer_activation.get(layer, None)
+        if activate_action is not None:
+            for action in activate_action:
+                action(self._m, layer)
+
     @property
     def bg_layer(self):
         return self._bg_layer
@@ -804,15 +816,7 @@ class BlitManager:
         self._bg_layer = val
 
         # a general callable to be called on every layer change
-        if len(self._on_layer_change) > 0:
-            for action in self._on_layer_change:
-                action(self._m, val)
-
-        # individual callables executed if a specific layer is activated
-        activate_action = self._on_layer_activation.get(val, None)
-        if activate_action is not None:
-            for action in activate_action:
-                action(self._m, val)
+        self._do_on_layer_change(layer=val)
 
         for m in [self._m.parent, *self._m.parent._children]:
             if m.layer != val:

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -29,13 +29,13 @@ def pairwise(iterable, pairs=2):
     return zip(*x)
 
 
-def _sanitize(s):
+def _sanitize(s, prefix="layer_"):
     # taken from https://stackoverflow.com/a/3303361/9703451
     s = str(s)
     # Remove leading characters until we find a letter or underscore
     s2 = re.sub("^[^a-zA-Z_]+", "", s)
     if len(s2) == 0:
-        s2 = _sanitize("layer_" + str(s))
+        s2 = _sanitize(prefix + str(s))
     # replace invalid characters with an underscore
     s = re.sub("[^0-9a-zA-Z_]", "_", s2)
     return s

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -824,17 +824,17 @@ class BlitManager:
         # a general callable to be called on every layer change
         self._do_on_layer_change(layer=val)
 
+        # hide all colorbars that are not no the visible layer
         for m in [self._m.parent, *self._m.parent._children]:
-            if m.layer != val:
-                if hasattr(m.figure, "ax_cb") and m.figure.ax_cb is not None:
-                    m.figure.ax_cb.set_visible(False)
-                if hasattr(m.figure, "ax_cb_plot") and m.figure.ax_cb_plot is not None:
-                    m.figure.ax_cb_plot.set_visible(False)
-            else:
-                if hasattr(m.figure, "ax_cb") and m.figure.ax_cb is not None:
-                    m.figure.ax_cb.set_visible(True)
-                if hasattr(m.figure, "ax_cb_plot") and m.figure.ax_cb_plot is not None:
-                    m.figure.ax_cb_plot.set_visible(True)
+            if getattr(m, "_colorbar", None) is not None:
+                [layer, cbgs, ax_cb, ax_cb_plot, orientation, cb] = m._colorbar
+
+                if layer != val:
+                    ax_cb.set_visible(False)
+                    ax_cb_plot.set_visible(False)
+                else:
+                    ax_cb.set_visible(True)
+                    ax_cb_plot.set_visible(True)
 
         # self.canvas.flush_events()
         self._clear_temp_artists("on_layer_change")

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -116,6 +116,7 @@ class searchtree:
     def query(self, x, k=1, d=None):
         if d is None:
             d = self.d
+
         # select a rectangle around the pick-coordinates
         # (provides tremendous speedups for very large datasets)
         mx = np.logical_and(
@@ -159,6 +160,7 @@ class searchtree:
                 )
 
             i = None
+
         return None, i
 
 
@@ -961,6 +963,7 @@ class BlitManager:
 
         # temporarily disconnect draw-event callback to avoid recursion
         # while we re-draw the artists
+
         cv.mpl_disconnect(self.cid)
 
         if not self._m._draggable_axes._modifier_pressed:
@@ -994,6 +997,7 @@ class BlitManager:
     def on_draw(self, event):
         """Callback to register with 'draw_event'."""
         cv = self.canvas
+
         if event is not None:
             if event.canvas != cv:
                 raise RuntimeError
@@ -1061,6 +1065,11 @@ class BlitManager:
 
             The default is 0.
         """
+
+        if not any(m.layer == layer for m in (self._m, *self._m._children)):
+            print(f"creating a new Maps-object for the layer {layer}")
+            self._m.new_layer(layer)
+
         if art.figure != self.canvas.figure:
             raise RuntimeError
 

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -127,17 +127,17 @@ class searchtree:
         )
         m = np.logical_and(mx, my)
         # get the indexes of the search-rectangle
-        idx = np.where(m)[0]
+        idx = np.where(m.ravel())[0]
         # evaluate the clicked pixel as the one with the smallest
         # euclidean distance
-
         if len(idx) > 0:
             i = idx[
                 (
-                    (self._m._props["x0"][m] - x[0]) ** 2
-                    + (self._m._props["y0"][m] - x[1]) ** 2
+                    (self._m._props["x0"][m].ravel() - x[0]) ** 2
+                    + (self._m._props["y0"][m].ravel() - x[1]) ** 2
                 ).argmin()
             ]
+
         else:
             # show some warning if no points are found within the pick_distance
 

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -324,12 +324,13 @@ class draggable_axes:
                 ax.set_position(bbox)
         if method == 1:  # e.g. ctrl + key pressed
             if self._cb_picked:
-                if self._m_picked._orientation == "vertical":
+                orientation = self._m_picked._colorbar[-2]
+                if orientation == "horizontal":
                     ratio = (
                         self._m_picked.figure.ax_cb_plot.bbox.height
                         / self._m_picked.figure.ax_cb.bbox.height
                     )
-                elif self._m_picked._orientation == "horizontal":
+                elif orientation == "vertical":
                     ratio = (
                         self._m_picked.figure.ax_cb_plot.bbox.width
                         / self._m_picked.figure.ax_cb.bbox.width
@@ -367,8 +368,9 @@ class draggable_axes:
                     self._ax_visible[self._m_picked.figure.ax_cb] = vis
 
                 # fix the visible ticks
+                orientation = self._m_picked._colorbar[-2]
                 if self._m_picked.figure.ax_cb.get_visible() is False:
-                    if self._m_picked._orientation == "horizontal":
+                    if orientation == "vertical":
                         self._m_picked.figure.ax_cb_plot.tick_params(
                             right=True,
                             labelright=True,
@@ -379,7 +381,7 @@ class draggable_axes:
                             top=False,
                             labeltop=False,
                         )
-                    elif self._m_picked._orientation == "vertical":
+                    elif orientation == "horizontal":
                         self._m_picked.figure.ax_cb_plot.tick_params(
                             bottom=True,
                             labelbottom=True,
@@ -391,7 +393,7 @@ class draggable_axes:
                             labelright=False,
                         )
                 else:
-                    if self._m_picked._orientation == "horizontal":
+                    if orientation == "vertical":
                         self._m_picked.figure.ax_cb_plot.tick_params(
                             right=False,
                             labelright=False,
@@ -402,7 +404,7 @@ class draggable_axes:
                             top=False,
                             labeltop=False,
                         )
-                    elif self._m_picked._orientation == "vertical":
+                    elif orientation == "horizontal":
                         self._m_picked.figure.ax_cb_plot.tick_params(
                             bottom=False,
                             labelbottom=False,
@@ -459,9 +461,10 @@ class draggable_axes:
             if not self._cb_picked:
                 ax.set_position(bbox)
             else:
-                if self._m_picked._orientation == "vertical":
+                orientation = self._m_picked._colorbar[-2]
+                if orientation == "horizontal":
                     b = [bbox.x0, bbox.y0, bbox.width, b[3] + bbox.height]
-                elif self._m_picked._orientation == "horizontal":
+                elif orientation == "vertical":
                     b = [bbox.x0, bbox.y0, b[2] + bbox.width, bbox.height]
 
         if (
@@ -613,14 +616,15 @@ class draggable_axes:
                     )
                 )
             else:
-                if self._m_picked._orientation == "vertical":
+                orientation = self._m_picked._colorbar[-2]
+                if orientation == "horizontal":
                     b = [
                         pos.x0 - wstep / 2,
                         pos.y0 - hstep / 2,
                         pos.width + wstep,
                         b[3] + pos.height + hstep,
                     ]
-                elif self._m_picked._orientation == "horizontal":
+                elif orientation == "vertical":
                     b = [
                         pos.x0 - wstep / 2,
                         pos.y0 - hstep / 2,
@@ -862,12 +866,9 @@ class BlitManager:
             should be called whenever a layer is activated.
             The default is False.
 
-        Returns
-        -------
-        inner : TYPE
-            DESCRIPTION.
 
         """
+
         if layer is None:
             if not persistent:
 

--- a/eomaps/helpers.py
+++ b/eomaps/helpers.py
@@ -1132,17 +1132,28 @@ class BlitManager:
 
     def _clear_temp_artists(self, method):
         if method == "on_layer_change":
-            # clear all artists from the "on_layer_change" list irrespective of the
-            # method
+            # clear all artists from "on_layer_change" list irrespective of the method
             allmethods = [i for i in self._artists_to_clear if i != method]
             for art in self._artists_to_clear[method]:
                 for met in allmethods:
+
                     if art in self._artists_to_clear[met]:
                         art.set_visible(False)
                         self.remove_artist(art)
                         art.remove()
                         self._artists_to_clear[met].remove(art)
             del self._artists_to_clear[method]
+
+            # always clear all temporary "pick" artists on a layer-change
+            for method in ["pick"]:
+                while len(self._artists_to_clear[method]) > 0:
+                    art = self._artists_to_clear[method].pop(-1)
+                    art.set_visible(False)
+                    self.remove_artist(art)
+                    art.remove()
+                    if art in self._artists_to_clear["on_layer_change"]:
+                        self._artists_to_clear["on_layer_change"].remove(art)
+                del self._artists_to_clear[method]
 
         else:
             while len(self._artists_to_clear[method]) > 0:

--- a/eomaps/reader.py
+++ b/eomaps/reader.py
@@ -592,6 +592,21 @@ def _from_file(
             )
             pass
 
+        # don't try to plot ellipses if the dataset is larger than 2M points
+        if _pd_OK and isinstance(m.data, pd.DataFrame):
+            # get the data-values
+            size = m.data[m.data_specs.parameter].size
+        else:
+            size = m.data.size
+
+        if size > 2000_000:
+            raise AssertionError(
+                "EOmaps: ...aborting attempt to plot "
+                + f"{np.format_float_scientific(size)} datapoints from a file "
+                + "as ellipses to avoid a memory-overflow... explicitly use "
+                + "`shape='ellipses'` if you really want to create an ellipse-plot!"
+            )
+
         # try to plot as ellipses
         m.set_shape.ellipses()
         m.plot_map(**kwargs)

--- a/eomaps/scalebar.py
+++ b/eomaps/scalebar.py
@@ -814,7 +814,6 @@ class ScaleBar:
             s.set_label_props(offset=o)
 
         def addcbs(self, s, **kwargs):
-            self.cb.click._only.append(s._cid_remove_cbs.split("__", 1)[0])
 
             # make sure we pick always only one scalebar
             for i in s._existing_pickers:
@@ -826,7 +825,6 @@ class ScaleBar:
 
             if not hasattr(s, "_cid_move"):
                 s._cid_move = self.cb.click.attach(scb_move, s=s)
-                self.cb.click._only.append(s._cid_move.split("__", 1)[0])
 
             if not hasattr(s, "_cid_up"):
                 s._cid_up = self.cb.keypress.attach(scb_az_ud, key="+", up=True, s=s)
@@ -903,7 +901,6 @@ class ScaleBar:
 
         self._m.cb.pick[self._picker_name].is_picked = False
 
-        self._m.cb.click._only.clear()
         self.set_position()
 
     def _decorate_zooms(self):

--- a/eomaps/utilities.py
+++ b/eomaps/utilities.py
@@ -274,7 +274,7 @@ class _layer_selector:
         self._selectors.append(s)
 
         # update widgets to make sure the right layer is selected
-        self._update_widgets(self._m.layer)
+        self._update_widgets(self._m.BM.bg_layer)
 
         return s
 
@@ -440,7 +440,7 @@ class _layer_selector:
         s.remove = remove
 
         # update widgets to make sure the right layer is selected
-        self._update_widgets(self._m.layer)
+        self._update_widgets(self._m.BM.bg_layer)
 
         return s
 

--- a/eomaps/utilities.py
+++ b/eomaps/utilities.py
@@ -196,7 +196,8 @@ class _layer_selector:
         exclude_layers : list or None
             A list of layer-names that should be excluded.
             Only relevant if `layers=None` is used.
-            The default is None
+            The default is None in which case only the "all" layer is excluded.
+            (Same as `exclude = ["all"]`. Use `exclude=[]` to get all available layers.)
         kwargs :
             All additional arguments are passed to `plt.legend`
 
@@ -231,6 +232,8 @@ class _layer_selector:
         """
 
         if layers is None:
+            if exclude_layers is None:
+                exclude_layers = ["all"]
             layers = self._m._get_layers(exclude=exclude_layers)
 
         assert (
@@ -325,8 +328,8 @@ class _layer_selector:
         exclude_layers : list or None
             A list of layer-names that should be excluded.
             Only relevant if `layers=None` is used.
-            The default is None
-
+            The default is None in which case only the "all" layer is excluded.
+            (Same as `exclude = ["all"]`. Use `exclude=[]` to get all available layers.)
         kwargs :
             Additional kwargs are passed to matplotlib.widgets.Slider
 
@@ -358,6 +361,8 @@ class _layer_selector:
 
         """
         if layers is None:
+            if exclude_layers is None:
+                exclude_layers = ["all"]
             layers = self._m._get_layers(exclude=exclude_layers)
 
         assert (

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ try:
 except Exception:
     long_description = "A library to create interactive maps of geographical datasets."
 
-version = "3.3.2"
+version = "3.4"
 
 setup(
     name="EOmaps",

--- a/tests/example1.py
+++ b/tests/example1.py
@@ -25,7 +25,7 @@ m.set_data(
 m.plot_map()
 m.add_colorbar()
 
-c = m.add_compass((0.05, 0.86), 7, patch=None)
+c = m.add_compass((0.05, 0.86), scale=7, patch=None)
 
 m.cb.pick.attach.annotate()  # attach a basic pick-annotation (on left-click)
 m.add_logo()  # add a logo

--- a/tests/example2.py
+++ b/tests/example2.py
@@ -11,6 +11,7 @@ data = pd.DataFrame(
 )
 data = data.sample(4000)  # take 4000 random datapoints from the dataset
 # ------------------------------------
+
 # initialize a grid of Maps objects
 mg = MapsGrid(
     1,
@@ -18,7 +19,7 @@ mg = MapsGrid(
     crs=[4326, Maps.CRS.Stereographic(), 3035],
     figsize=(11, 5),
     bottom=0.15,
-    layer="first layer",
+    layer="layer 1",
 )
 # set the data on ALL maps-objects of the grid
 mg.set_data(data=data, xcoord="lon", ycoord="lat", in_crs=4326)
@@ -38,7 +39,8 @@ mg.m_0_2.ax.set_extent(mg.m_0_2.crs_plot.area_of_use.bounds)
 
 mg.m_0_2.ax.set_title("epsg=3035")
 mg.m_0_2.set_classify_specs(
-    scheme="StdMean", multiples=[-1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1]
+    scheme="StdMean",
+    multiples=[-1, -0.75, -0.5, -0.25, 0.25, 0.5, 0.75, 1],
 )
 
 # --------- plot all maps and add colorbars to all maps
@@ -55,47 +57,28 @@ mg.add_feature.preset.coastline(layer="all")  # add the coastline to all layers
 
 # NOTE: this layer is not visible by default but it can be shown by clicking
 # on the layer-switcher utility buttons (bottom center of the figure)
-m2 = mg.m_0_1.new_layer(
-    layer="layer 2 for second axis", copy_data_specs=True, copy_plot_specs=True
-)
+# or by using `m2.show()`   or via  `m.show_layer("layer 2")`
+m2 = mg.m_0_1.new_layer(layer="layer 2", copy_data_specs=True, copy_plot_specs=True)
 m2.set_shape.delaunay_triangulation(mask_radius=max(m2.shape.radius) * 2)
 m2.set_classify_specs(scheme="Quantiles", k=4)
 m2.set_plot_specs(cmap="RdYlBu")
 m2.plot_map()
 m2.add_colorbar()
-
+# add an annotation that is only executed if "layer 2" is active
+m2.cb.click.attach.annotate(text="callbacks are layer-sensitive!")
 
 # --------- add some callbacks to indicate the clicked data-point to all maps
 for m in mg:
-    m.cb.pick.attach.mark(
-        fc="r",
-        ec="none",
-        buffer=1,
-        permanent=True,
-    )
-    m.cb.pick.attach.mark(
-        fc="none",
-        ec="r",
-        lw=1,
-        buffer=5,
-        permanent=True,
-    )
+    m.cb.pick.attach.mark(fc="r", ec="none", buffer=1, permanent=True)
+    m.cb.pick.attach.mark(fc="none", ec="r", lw=1, buffer=5, permanent=True)
+    m.cb.click.attach.mark(fc="none", ec="k", lw=2, buffer=10, permanent=False)
 
-    m.cb.click.attach.mark(
-        fc="none",
-        ec="k",
-        lw=2,
-        buffer=10,
-        permanent=False,
-    )
-    m.add_logo()
 # add an annotation-callback to the second map
 mg.m_0_1.cb.pick.attach.annotate(text="the closest point is here!", zorder=99)
 
 # share click & pick-events between all Maps-objects of the MapsGrid
 mg.share_click_events()
 mg.share_pick_events()
-
 
 # --------- add a layer-selector widget
 mg.util.layer_selector(ncol=2, loc="lower center", draggable=False)
@@ -104,6 +87,9 @@ mg.util.layer_selector(ncol=2, loc="lower center", draggable=False)
 for m in mg:
     m.figure.ax_cb.tick_params(rotation=90, labelsize=8)
 m2.figure.ax_cb.tick_params(rotation=90, labelsize=8)
+
+# add logos to all maps
+mg.add_logo()
 
 # trigger a final re-draw of all layers to make sure the manual
 # changes to the ticks are properly reflected in the cached layers.

--- a/tests/example4.py
+++ b/tests/example4.py
@@ -1,5 +1,6 @@
 # EOmaps example 4: Turn your maps into a powerful widgets
 
+# %matplotlib widget
 from eomaps import Maps
 import pandas as pd
 import numpy as np
@@ -116,7 +117,7 @@ def cb1(self, pos, ID, val, **kwargs):
         f"You clicked on {nvals} pixel"
         + ("s" if nvals > 1 else "")
         + "!\n... and the "
-        + ("average" if nvals > 1 else "")
+        + ("average " if nvals > 1 else "")
         + f"value is {np.mean(self.cb.pick.get.picked_vals['val']):.3f}"
     )
 

--- a/tests/example5.py
+++ b/tests/example5.py
@@ -69,17 +69,16 @@ m2.cb.click.attach(callback)
 
 # --------- add some basic overlays from NaturalEarth
 
-f0 = m.add_feature.physical_10m.lakes(ec="none", fc="b", zorder=100)
-f1 = m.add_feature.physical_10m.rivers_lake_centerlines(
+m.add_feature.preset.coastline("10m", zorder=101)
+m.add_feature.physical_10m.lakes(ec="none", fc="b", zorder=100)
+m.add_feature.physical_10m.rivers_lake_centerlines(
     ec="b", fc="none", lw=0.5, zorder=100
 )
-f2 = m.add_feature.cultural_10m.admin_0_countries(
-    ec=".75", fc="none", lw=0.5, zorder=100
-)
-f3 = m.add_feature.cultural_10m.urban_areas(ec="none", fc="r")
+m.add_feature.cultural_10m.admin_0_countries(ec=".75", fc="none", lw=0.5, zorder=100)
+m.add_feature.cultural_10m.urban_areas(ec="none", fc="r")
 
 # add a customized legend
-m.figure.ax.legend(
+leg = m.figure.ax.legend(
     [
         Patch(fc="b"),
         plt.Line2D([], [], c="b"),
@@ -92,6 +91,9 @@ m.figure.ax.legend(
     facecolor="w",
     framealpha=1,
 )
+# add the legend to the blit-manager to keep it on top of dynamically updated artists
+leg.zorder = 999
+m.BM.add_artist(leg)
 
 # --------- add some fancy (static) indicators for selected pixels
 mark_id = 6060
@@ -103,6 +105,7 @@ for buffer in np.linspace(1, 5, 10):
         fc=[1, 0, 0, 0.1],
         ec="r",
         buffer=buffer * 5,
+        n=100,  # use 100 points to represet the ellipses
     )
 m.add_marker(
     ID=mark_id, shape="rectangles", radius="pixel", fc="g", ec="y", buffer=3, alpha=0.5
@@ -157,5 +160,5 @@ m.add_annotation(
     arrowprops=dict(arrowstyle="fancy", facecolor="w", connectionstyle="arc3,rad=0.35"),
 )
 
-m.add_colorbar(label="The Data")
+cb = m.add_colorbar(label="The Data")
 m.add_logo()

--- a/tests/example6.py
+++ b/tests/example6.py
@@ -12,13 +12,12 @@ data = pd.DataFrame(
 )
 # --------------------------------
 
-m = Maps(Maps.CRS.GOOGLE_MERCATOR)
+m = Maps(Maps.CRS.GOOGLE_MERCATOR, layer="S1GBM_vv")
 # set the crs to GOOGLE_MERCATOR to avoid reprojecting the WebMap data
 # (makes it a lot faster and it will also look much nicer!)
 # ------------- LAYER 0
 # add a layer showing S1GBM
-m1 = m.new_layer(layer="S1GBM_vv")
-m1.add_wms.S1GBM.add_layer.vv()
+m.add_wms.S1GBM.add_layer.vv()
 
 # ------------- LAYER 1
 # if you just want to add features, you can also do it within the same Maps-object!
@@ -40,17 +39,17 @@ m2.cb.pick.attach.annotate(zorder=100)  # use a high zorder to put it on top
 
 # on a left-click, show layers ("data", "OSM") in a rectangle
 # (with a size of 20% of the axis)
-m.cb.click.attach.peek_layer(layer=["data", "OSM"], how=0.2)
+m.all.cb.click.attach.peek_layer(layer=["data", "OSM"], how=0.2)
 
 # on a right-click, "swipe" the layers ("data", "S1GBM_vv") from the left
-m.cb.click.attach.peek_layer(
+m.all.cb.click.attach.peek_layer(
     layer=["data", "S1GBM_vv"], how="left", button=3, overlay=True
 )
 
 # switch between the layers with the keys 0, 1 and 2
-m.cb.keypress.attach.switch_layer(layer="S1GBM_vv", key="0")
-m.cb.keypress.attach.switch_layer(layer="OSM", key="1")
-m.cb.keypress.attach.switch_layer(layer="data", key="2")
+m.all.cb.keypress.attach.switch_layer(layer="S1GBM_vv", key="0")
+m.all.cb.keypress.attach.switch_layer(layer="OSM", key="1")
+m.all.cb.keypress.attach.switch_layer(layer="data", key="2")
 
 # ------------------------------
 m.figure.f.set_size_inches(9, 4)

--- a/tests/example6.py
+++ b/tests/example6.py
@@ -1,5 +1,6 @@
 # EOmaps example 6: WebMap services and layer-switching
 
+# %matplotlib widget
 from eomaps import Maps
 import numpy as np
 import pandas as pd
@@ -11,37 +12,42 @@ data = pd.DataFrame(
 )
 # --------------------------------
 
-m = Maps(Maps.CRS.GOOGLE_MERCATOR, layer="S1GBM_vv")
+m = Maps(Maps.CRS.GOOGLE_MERCATOR)
 # set the crs to GOOGLE_MERCATOR to avoid reprojecting the WebMap data
 # (makes it a lot faster and it will also look much nicer!)
 # ------------- LAYER 0
-# add S1GBM as a base-layer
-wms1 = m.add_wms.S1GBM
-wms1.add_layer.vv()
+# add a layer showing S1GBM
+m1 = m.new_layer(layer="S1GBM_vv")
+m1.add_wms.S1GBM.add_layer.vv()
 
 # ------------- LAYER 1
-# if you just want to add features, you can do it within the same Maps-object!
-# add OpenStreetMap on the currently invisible layer (1)
-wms2 = m.add_wms.OpenStreetMap  # .OSM_mundialis
-wms2.add_layer.default(layer="OSM")
+# if you just want to add features, you can also do it within the same Maps-object!
+# add OpenStreetMap on the currently invisible layer (OSM)
+m.add_wms.OpenStreetMap.add_layer.default(layer="OSM")
 
 # ------------- LAYER 2
-# create a connected maps-object and plot some data on a new layer (2)
+# create a new layer and plot some data
 m2 = m.new_layer(layer="data")
 m2.set_data(data=data.sample(5000), xcoord="lon", ycoord="lat", crs=4326)
 m2.set_shape.geod_circles(radius=20000)
 m2.plot_map()
 
-# ------------ CALLBACKS
-# on a left-click, show layer 1 in a rectangle (with a size of 20% of the axis)
-m.cb.click.attach.peek_layer(layer=["data", "OSM"], how=(0.2, 0.2))
+# add a callback that is only executed if the "data" layer is visible
+m2.cb.pick.attach.annotate(zorder=100)  # use a high zorder to put it on top
 
-# on a right-click, "swipe" layer (2) from the left
+# ------------ CALLBACKS
+# since m.layer == "all", the callbacks assigned to "m" will be executed on all layers!
+
+# on a left-click, show layers ("data", "OSM") in a rectangle
+# (with a size of 20% of the axis)
+m.cb.click.attach.peek_layer(layer=["data", "OSM"], how=0.2)
+
+# on a right-click, "swipe" the layers ("data", "S1GBM_vv") from the left
 m.cb.click.attach.peek_layer(
     layer=["data", "S1GBM_vv"], how="left", button=3, overlay=True
 )
 
-
+# switch between the layers with the keys 0, 1 and 2
 m.cb.keypress.attach.switch_layer(layer="S1GBM_vv", key="0")
 m.cb.keypress.attach.switch_layer(layer="OSM", key="1")
 m.cb.keypress.attach.switch_layer(layer="data", key="2")
@@ -53,11 +59,20 @@ m.figure.gridspec.update(left=0.01, right=0.99, bottom=0.01, top=0.99)
 m.add_logo()
 
 # add a utility-widget for switching the layers
-m.util.layer_selector(loc="upper left", ncol=3, bbox_to_anchor=(0.01, 0.99))
+m.util.layer_selector(
+    loc="upper left",
+    ncol=3,
+    bbox_to_anchor=(0.01, 0.99),
+    layers=["OSM", "S1GBM_vv", "data"],
+)
 
 m.util.layer_slider(
     pos=(0.5, 0.93, 0.38, 0.025),
     color="r",
     handle_style=dict(facecolor="r"),
     txt_patch_props=dict(fc="w", ec="none", alpha=0.75, boxstyle="round, pad=.25"),
+    layers=["OSM", "S1GBM_vv", "data"],
 )
+
+# show the S1GBM layer on start
+m.show_layer("S1GBM_vv")

--- a/tests/example8.py
+++ b/tests/example8.py
@@ -7,8 +7,6 @@ plt.get_backend()
 
 m = Maps(figsize=(9, 5))
 m.add_feature.preset.ocean(ec="k", scale="110m")
-m.cb.click.attach.annotate()
-
 
 s1 = m.add_scalebar(
     -11,

--- a/tests/example_row_col_selector.py
+++ b/tests/example_row_col_selector.py
@@ -1,3 +1,4 @@
+# %matplotlib widget
 from eomaps import Maps, MapsGrid
 import numpy as np
 import itertools
@@ -16,7 +17,7 @@ mg = MapsGrid(
     m_inits={"map": (slice(0, 2), 0)},
     ax_inits={"row": (0, 1), "col": (1, 1)},
     crs=Maps.CRS.InterruptedGoodeHomolosine(),
-    figsize=(12, 5),
+    figsize=(8, 5),
 )
 
 mg.gridspec.update(top=0.95, bottom=0.1, left=0.01, right=0.99, hspace=0.3, wspace=0.15)

--- a/tests/test_basic_functions.py
+++ b/tests/test_basic_functions.py
@@ -173,7 +173,7 @@ class TestBasicPlotting(unittest.TestCase):
         plt.close(m.figure.f)
 
     def test_add_callbacks(self):
-        m = Maps(3857)
+        m = Maps(3857, layer="layername")
         m.data = self.data.sample(10)
         m.set_data_specs(xcoord="x", ycoord="y", in_crs=3857)
         m.set_shape.ellipses(radius=200000)
@@ -194,7 +194,7 @@ class TestBasicPlotting(unittest.TestCase):
 
             self.assertTrue(
                 cbID
-                == f"{cb}_0__{'double' if double_click else 'single'}__{mouse_button}"
+                == f"{cb}_0__{m.layer}__{'double' if double_click else 'single'}__{mouse_button}"
             )
             self.assertTrue(len(m.cb.pick.get.attached_callbacks) == 1)
             m.cb.pick.remove(cbID)
@@ -214,7 +214,7 @@ class TestBasicPlotting(unittest.TestCase):
 
             self.assertTrue(
                 cbID
-                == f"{cb}_0__{'double' if double_click else 'single'}__{mouse_button}"
+                == f"{cb}_0__{m.layer}__{'double' if double_click else 'single'}__{mouse_button}"
             )
             self.assertTrue(len(m.cb.click.get.attached_callbacks) == 1)
             m.cb.click.remove(cbID)

--- a/tests/test_basic_functions.py
+++ b/tests/test_basic_functions.py
@@ -232,7 +232,7 @@ class TestBasicPlotting(unittest.TestCase):
 
             cbID = m.cb.keypress.attach(cb, key=key)
 
-            self.assertTrue(cbID == f"{cb}_0__{key}")
+            self.assertTrue(cbID == f"{cb}_0__{m.layer}__{key}")
             self.assertTrue(len(m.cb.keypress.get.attached_callbacks) == 1)
             m.cb.keypress.remove(cbID)
             self.assertTrue(len(m.cb.keypress.get.attached_callbacks) == 0)

--- a/tests/test_basic_functions.py
+++ b/tests/test_basic_functions.py
@@ -445,7 +445,7 @@ class TestBasicPlotting(unittest.TestCase):
         mgrid.parent._draggable_axes._make_draggable()
         mgrid.parent._draggable_axes._undo_draggable()
 
-        m = Maps(orientation="horizontal")
+        m = Maps()
         m.plot_map()
         m._draggable_axes._make_draggable()
         m._draggable_axes._undo_draggable()


### PR DESCRIPTION
A major release that brings a lot of updates on speed and memory management and some very nice (but possibly breaking) changes compared previous versions of EOmaps.  

## ❗ IMPORTANT CHANGES ❗ 

### ⭐ Starting with EOmaps v3.4 all callbacks and colorbars are layer-specific !
This means that callbacks only trigger if the layer of the associated `Maps` object is visible!
(...and colorbars are only visible if the associated layer is visible)

- To trigger callbacks or add features & datasets independent of the visible layer, use `m.all.cb. ...`   
  (or attach them to a `Maps` object on the `"all"` layer)
- **Note:** `pick` callbacks now always react to the visible collection!
  (except for the ones on the `"all"` layer)

    ```python
    m = Maps(layer=0)
    m.cb.click.attach.annotate()       # this callback is ONLY executed if the layer 0 is visible
   
    m1 = m.new_layer(layer=1)
    m1.cb.click.attach.mark()          # this callback is ONLY executed if the layer 1 is visible

    m.all.cb.click.attach.annotate()   # this callback is executed independent of the visible layer!
    ```

### 🍃 removed arguments
- the obsolete `"orientation"` argument has been removed from `Maps(...)` 
  (it set the colorbar-orientation which is now specified via `m.add_colorbar(orientation=...)`
---

### 🌳 NEW
- ⭐ `m.show()` can be used to make the associated layer visible. (a shortcut for `m.show_layer(m.layer)`
- ⭐ `m.BM.on_layer(...)` can be used to trigger functions if the visible layer changes.
- 🌟 WebMap layers are now lazily evaluated and only added to the map if the corresponding layer is actually visible.
- 🌟 [experimental feature] memory-mapping can now be used to avoid using up a lot of ram for very large datasets
   - Intermediate datasets are stored as memory-mapped files in a temp-folder on disk to release memory
   - By default memory-mapping is disabled! (to activate it, use: `m.plot_map(memmap=False)` )

### 🌦️ changes
- Adding data from files (e.g. `m.from_file` or `m.new_layer_from_file`) now **always** uses `"shade_raster"` as the default plot-shape  (since EOmaps v3.3.2, raster-shading works perfectly fine with re-projected rasters as well)
- If a file with >2M data-points is plotted, only "shade" shapes are attempted by default to avoid overloading memory.
- only one colorbar is allowed for ``Maps`` objects (use multiple objects for multiple colorbars)

### 🔨 fixes
- Fix several issues with memory-leaks and garbage-collection of objects
- Fix autoscale_fraction not recognized when using `preset="bw"` in `m.add_scalebar`
- Maps objects are now properly garbage-collected
- Fix auto-scaling of scalebars for very small scales
- `Maps.from_file` now properly handles `pathlib.Path` objects
- Fix utility widget start-layer should be the currently visible layer
- Fix pick-events should only identify points on visible layers
- Fix `m.add_colorbar(log=True)` for horizontal colorbars
- Fix colorbar limit autoscaling
- Fix logo size changes on zoom
- Remove obsolete `layer` kwarg from `m.add_logo`
- Fix incorrect color-normalization for `shade_raster` or `shade_points` if `vmin/vmax` outside the data-range are used 
  (thanks to @maxhollmann)
