### PR TITLE
_shade_map normalizes vmin and vmax instead of recalculating them from normalized zdata

### DIFF
--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -2312,7 +2312,7 @@ class Maps(object):
             return
 
         # re-evaluate vmin and vmax after normalization
-        vmin, vmax = np.nanmin(zdata), np.nanmax(zdata)
+        vmin, vmax = self.classify_specs._norm([vmin, vmax]).astype(float)
         # re-instate masked values
         zdata[~z_finite] = np.nan
 


### PR DESCRIPTION
Hey Raphael, thanks for this library, it's been very useful to me!

I noticed that the vmin & vmax values weren't respected when using shaders. The colorbar used the range set by `set_plot_specs`, but the colors drawn on the map itself were using the min/max of the normalized values. This fixes it by normalizing the existing vmin/vmax instead of recalculating them after normalization.