### PR TITLE
Error in api docs - reading NetCDF files

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1591,7 +1591,7 @@ Read relevant data from a file
 .. code-block:: python
 
     m = Maps()
-    data = m.read_data.NetCDF(
+    data = m.read_file.NetCDF(
         "the filepath",
         parameter="adsf",
         coords=("longitude", "latitude"),


### PR DESCRIPTION
NetCDF reading is called from `m.read_file` module not nonexistant `m.read_data` 

Checked by:
"read_data" was the only occurrence in the whole repo.