### PR TITLE
Merge for v4.4.1

### DIFF
--- a/eomaps/_webmap.py
+++ b/eomaps/_webmap.py
@@ -365,7 +365,12 @@ class _wmts_layer(_WebMap_layer):
                     self._m.new_layer(layer=self._layer)
                 # delay adding the layer until it is effectively activated
                 self._m.BM.on_layer(
-                    partial(self._do_add_layer),
+                    func=partial(
+                        self._do_add_layer,
+                        wms_kwargs=kwargs,
+                        zorder=zorder,
+                        alpha=alpha,
+                    ),
                     layer=self._layer,
                     persistent=False,
                     m=m,
@@ -389,19 +394,13 @@ class _wmts_layer(_WebMap_layer):
             ax.add_image(img)
         return img
 
-    def _do_add_layer(self, m, l):
+    def _do_add_layer(self, m, l, **kwargs):
         # actually add the layer to the map.
         print(f"EOmaps: Adding wmts-layer: {self.name}")
 
         # use slightly adapted implementation of cartopy's ax.add_wmts
         art = self._add_wmts(
-            m.ax,
-            self._wms,
-            self.name,
-            wms_kwargs=self._kwargs,
-            interpolation="spline36",
-            zorder=self._zorder,
-            alpha=self._alpha,
+            m.ax, self._wms, self.name, interpolation="spline36", **kwargs
         )
 
         # art = m.figure.ax.add_wmts(
@@ -457,10 +456,6 @@ class _wms_layer(_WebMap_layer):
         if self._style is not None:
             kwargs["styles"] = [self._style]
 
-        self._kwargs = kwargs
-        self._zorder = zorder
-        self._alpha = alpha
-
         for m in self._m if isinstance(self._m, MapsGrid) else [self._m]:
 
             if layer is None:
@@ -477,7 +472,12 @@ class _wms_layer(_WebMap_layer):
                     self._m.new_layer(layer=self._layer)
                 # delay adding the layer until it is effectively activated
                 m.BM.on_layer(
-                    func=partial(self._do_add_layer),
+                    func=partial(
+                        self._do_add_layer,
+                        wms_kwargs=kwargs,
+                        zorder=zorder,
+                        alpha=alpha,
+                    ),
                     layer=layer,
                     persistent=False,
                     m=m,
@@ -503,28 +503,14 @@ class _wms_layer(_WebMap_layer):
 
         return img
 
-    def _do_add_layer(self, m, l):
+    def _do_add_layer(self, m, l, **kwargs):
         # actually add the layer to the map.
         print(f"EOmaps: ... adding wms-layer {self.name}")
 
         # use slightly adapted implementation of cartopy's ax.add_wms
         art = self._add_wms(
-            m.ax,
-            self._wms,
-            self.name,
-            wms_kwargs=self._kwargs,
-            interpolation="spline36",
-            zorder=self._zorder,
-            alpha=self._alpha,
+            m.ax, self._wms, self.name, interpolation="spline36", **kwargs
         )
-
-        # art = m.figure.ax.add_wms(
-        #     self._wms,
-        #     self.name,
-        #     wms_kwargs=kwargs,
-        #     interpolation="spline36",
-        #     zorder=zorder,
-        # )
 
         m.BM.add_bg_artist(art, l)
 
@@ -1086,28 +1072,27 @@ class _xyz_tile_service:
                 )
         else:
 
-            self._kwargs = dict(
-                interpolation=interpolation, alpha=alpha, origin="lower"
-            )
-            self._kwargs.update(kwargs)
-            self._zorder = zorder
+            kwargs.setdefault("interpolation", interpolation)
+            kwargs.setdefault("zorder", zorder)
+            kwargs.setdefault("alpha", alpha)
+            kwargs.setdefault("origin", "lower")
 
             if self._layer == "all" or self._m.BM.bg_layer == self._layer:
                 # add the layer immediately if the layer is already active
-                self._do_add_layer(self._m, self._layer)
+                self._do_add_layer(self._m, self._layer, **kwargs)
             else:
                 if self._layer not in self._m._get_layers():
                     # create a new (empty) layer so that utility-widgets get updated!
                     self._m.new_layer(layer=self._layer)
                 # delay adding the layer until it is effectively activated
                 self._m.BM.on_layer(
-                    func=self._do_add_layer,
+                    func=partial(self._do_add_layer, **kwargs),
                     layer=self._layer,
                     persistent=False,
                     m=self._m,
                 )
 
-    def _do_add_layer(self, m, l):
+    def _do_add_layer(self, m, l, **kwargs):
         # actually add the layer to the map.
         print(f"EOmaps: ... adding wms-layer {self.name}")
 
@@ -1125,9 +1110,7 @@ class _xyz_tile_service:
         #         (only SlippyImageArtist has been subclassed)
 
         self._raster_source.validate_projection(m.ax.projection)
-        img = SlippyImageArtist_NEW(
-            m.ax, self._raster_source, zorder=self._zorder, **self._kwargs
-        )
+        img = SlippyImageArtist_NEW(m.ax, self._raster_source, **kwargs)
         with self._m.ax.hold_limits():
             m.ax.add_image(img)
         self._artist = img
@@ -1202,7 +1185,7 @@ class SlippyImageArtist_NEW(AxesImage):
                 super().draw(renderer, *args, **kwargs)
 
             self.stale = False
-        except:
+        except Exception:
             print("EOmaps: ... could not fetch WebMap service")
 
             if self in self.axes._mouseover_set:

--- a/eomaps/_webmap.py
+++ b/eomaps/_webmap.py
@@ -342,13 +342,9 @@ class _wmts_layer(_WebMap_layer):
         """
         from . import MapsGrid  # do this here to avoid circular imports!
 
-        self._style = self._set_style(kwargs.get("styles", None))
-        if self._style is not None:
-            kwargs["styles"] = [self._style]
-
-        self._zorder = zorder
-        self._kwargs = kwargs
-        self._alpha = alpha
+        styles = self._set_style(kwargs.get("styles", None))
+        if styles is not None:
+            kwargs["styles"] = styles
 
         for m in self._m if isinstance(self._m, MapsGrid) else [self._m]:
             if layer is None:
@@ -452,9 +448,9 @@ class _wms_layer(_WebMap_layer):
         """
         from . import MapsGrid  # do this here to avoid circular imports!
 
-        self._style = self._set_style(kwargs.get("styles", None))
-        if self._style is not None:
-            kwargs["styles"] = [self._style]
+        styles = self._set_style(kwargs.get("styles", None))
+        if styles is not None:
+            kwargs["styles"] = styles
 
         for m in self._m if isinstance(self._m, MapsGrid) else [self._m]:
 


### PR DESCRIPTION
A quick bugfix release
### 🔨 Fixes
- fix providing kwargs to WebMap services (time, styles etc.)

----

# EOmaps v4.4
A release that introduces 2 new functionalities: `m.add_line`, `m.cb.move` and the ability to use **keypress-modifiers** for callbacks!

# 🌳 New
### 🚲 A new method to quickly draw paths on a map!
- ⭐ `m.add_line()`: connect points via geodesic (or straight) lines!
   - specify number of intermediate points per line-segment 
     - (alternatively) specify distance between intermediate points for each line-segment
     - checkout the new [🚲 example](https://eomaps.readthedocs.io/en/dev/EOmaps_examples.html#lines-and-annotations) and the corresponding section in the [📖 documentation!](https://eomaps.readthedocs.io/en/dev/api.html#lines)

<img src="https://github.com/raphaelquast/EOmaps/blob/dev/docs/_static/example_lines.png?raw=true" width=75%/>

## 🛸 New features for callbacks!

### 👾 Keypress-modifiers

It is now possible to assign multiple callbacks to **the same** mouse-button and use keyboard-shortcuts 
to switch between the assigned callbacks!
(e.g. the callback will only be executed if the corresponding button is pressed on the keyboard)


- 🌟 simply provide the modifier of choice with the `modifier=...` argument!
  - e.g.: `m.cb.click.attach.annotate(modifier="a")` : this callback will only be executed if the `"a"` key is pressed
- 🌟 You can make modifiers "sticky" (e.g. to keep them activated after the button is released)  by using:
  - `m.cb.click.set_sticky_modifiers("a", "b", "c")`
  - "sticky modifiers" are assigned separately for `click`, `pick` and `move` callbacks
  - to release a "sticky modifier" press `ctrl + <modifier key>` or `escape`

- checkout the corresponding section in the [📖 documentation!](https://eomaps.readthedocs.io/en/dev/api.html#using-modifiers-for-pick-click-and-move-callbacks)


### ⭐ `move` callbacks

There's now an explicit container to attach callbacks that are executed 
**on mouse movement if NO button is clicked**

- NOTE: use `m.cb.click.attach...` to execute callbacks on mouse-movement if a button is clicked!
  - and set `on_motion=False` to avoid executing the click-callback on mouse-movements

```python
m = Maps()
m.add_feature.preset.coastline()
m.cb.move.attach.annotate()
m.cb.move.attach.mark(modifier=1, radius=2, radius_crs=4326, fc="none", ec="r")
```

# 🌦️ Changes
- ❗ `m.cb.click.attach.mark()` now uses `permanent=False` by default

- 🏞️ NaturalEarth features have been updated
    
    <details>
    <summary> click for a list of new features</summary>
    
    ```python
    
    {
    10m_cultural:  {'admin_0_countries_iso', 'parks_and_protected_lands', 'admin_0_countries_tlc'}
    10m_physical:  {'bathymetry_G_4000', 'graticules_20', 'bathymetry_K_200', 'bathymetry_E_6000', 'graticules_1', 'bathymetry_A_10000', 'bathymetry_F_5000', 'bathymetry_C_8000', 'bathymetry_B_9000', 'bathymetry_L_0', 'bathymetry_H_3000', 'bathymetry_I_2000', 'wgs84_bounding_box', 'bathymetry_J_1000', 'graticules_5', 'bathymetry_D_7000', 'graticules_30', 'graticules_10', 'graticules_15'}
    110m_physical:  {'graticules_15', 'graticules_20', 'graticules_1', 'wgs84_bounding_box', 'graticules_5', 'graticules_30', 'graticules_10'}
    50m_physical:  {'graticules_20', 'graticules_1', 'wgs84_bounding_box', 'graticules_5', 'graticules_30', 'graticules_10', 'graticules_15'}
    }
    
    ```
    
    </details>


# 🔨 Fixes
- fix sharing boundary and inset-marker properties for inset-maps
- fix issues with invalid clipping shapes
- fix issues with geometries that cannot be exploded
- make sure temporary artists are cleared prior to executing callbacks
- fix issues with dynamically updated legends and temporary artists
- fix error when trying to update colorbar-arrows without a colorbar
- avoid re-fetching WebMap tiles if extent remains the same
- fix unnecessary re-draws of artists after overlay-actions
