### PR TITLE
update docs env

### DIFF
--- a/docs/docs_env.yml
+++ b/docs/docs_env.yml
@@ -4,33 +4,17 @@ channels:
 
 dependencies:
 
-  - numpy
-  - scipy
-  - pandas
-  - geopandas
-  - matplotlib >=3.4
-  - cartopy >=0.20.0
-  - descartes
-  - mapclassify
-  - pyproj
-  - pyepsg
-  # --------------for data-shading
-  - datashader
-  # --------------for GeoTIFF and NetCDF files
-  - netcdf4
-  - xarray
-  - rioxarray
-  # --------------for WebMaps
-  - owslib
-  - requests
-  - xmltodict
-  - cairosvg
+  - python =3.11
 
-  - pip
   # --------------for building the docs
-  - docutils<0.19
-  - sphinx=7.2.6
-  - sphinx-copybutton=0.5.2
-  - myst-nb=1.0.0
-  - sphinx-design=0.5.0
-  - sphinx_rtd_theme=1.3
+  - docutils =0.20.1
+  - sphinx =7.2.6
+  - sphinx-copybutton =0.5.2
+  - myst-nb =1.0.0
+  - sphinx-design =0.5.0
+  - sphinx_rtd_theme =2.0.0
+
+  # install minimal dependencies to import eomaps
+  - pip
+  - pip:
+    - ../.


### PR DESCRIPTION
Update docs-build to install only what's really needed -> build time cut in half!

## 🌦️ Changes
- update documentation environment to most recent build dependencies
- install only minimal requirements to import eomaps
