### PR TITLE
Quick bugfix release to include missing companion-widget source-files on install.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,7 +21,7 @@ EOmaps is available on [conda-forge](https://anaconda.org/conda-forge/eomaps) an
 conda install -c conda-forge eomaps
 ```
 
-This will install all required and optional dependencies.
+This will install all required dependencies as well as the optional dependencies ``pandas``, ``geopandas``, ``mapclassify``, ``datashader``, ``owslib``, ``requests`` and ``qtpy``
 
 
 :::{dropdown} Greatly speed up the installation!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,10 @@ wms = [
     "requests",
 ]
 
-shade = ["datashader"]
+shade = [
+    "datashader",
+    "dask[dataframe]",  # to address https://github.com/dask/dask/issues/10995
+]
 
 gui = [
     "PyQt5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["eomaps", "eomaps.scripts", "eomaps.qtcompanion"]
+include = ["eomaps", "eomaps.scripts", "eomaps.qtcompanion", "eomaps.qtcompanion.widgets"]
 
 [tool.setuptools.package-data]
 eomaps = ["logo.png", "NE_features.json", "qtcompanion/icons/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ eomaps = ["logo.png", "NE_features.json", "qtcompanion/icons/*"]
 
 [project]
 name = "eomaps"
-version = "8.0.1"
+version = "8.0.2"
 description = "A library to create interactive maps of geographical datasets."
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
### EOmaps v8.0.2
- fix issues with missing companion-widget source files
- fix issues with missing `dask-expr` dependency for `datashader`

# EOmaps v8.0
#### A new major release that brings a lot of important updates and improvements for EOmaps!

> A big thanks goes to @banesullivan, @yeelauren and @jhkennedy who provided many useful suggestions and comments to improve EOmaps in the [PyOpenSci](https://www.pyopensci.org/) review (https://github.com/pyOpenSci/software-submission/issues/138)!

# § New License!
The EOmaps source code is now licensed under a  [BSD 3 Clause License](https://choosealicense.com/licenses/bsd-3-clause) to make it easier for users and contributors to improve and extend the codebase and to use EOmaps to build awesome tools for geo-data analysis!

> Make sure to have a look at the [licensing-note](https://eomaps.readthedocs.io/en/dev/FAQ.html#licensing-and-redistribution) in the FAQ of the docs for some more details!

Interested in contributing to EOmaps? Checkout the updated [Contribution Guide](https://eomaps.readthedocs.io/en/dev/contribute.html)!

# ⚠️ Major changes to `pip` install

Dependency management for `EOmaps` has been improved to **split between required and optional dependencies**.

>❗`pip install eomaps` now **only installs the bare minimum requirements** to run `EOmaps`.
>❗To install EOmaps with **all optional dependencies**, use `pip install eomaps[all]`. 

Make sure to have a look at the updated [installation instructions](https://eomaps.readthedocs.io/en/latest/installation.html) in the docs for more details on how to selectively install optional dependencies!

# 🌳 New
- `m.set_data(...)` now directly accepts `xarray.Datasets` as input (see docs  on [how to assign datasets](https://eomaps.readthedocs.io/en/dev/api_data_visualization.html#assign-the-data))
- There is a new [pre-defined keypress callback](https://eomaps.readthedocs.io/en/dev/api_callbacks.html#pre-defined-keypress-callbacks): `overlay_layer` 
  - You can use it to toggle showing a layer on top of the currently visible layer.
    ```python
    m.all.cb.keypress.attach.overlay_layer(<layer-name>, key="a")
    ```
- The `switch_layer` keypress-callback now also accepts lists of layer-names (or lists of tuples `(name, transparency)`)
- [m.cb.pick.share_events()](https://eomaps.readthedocs.io/en/dev/generated/eomaps.eomaps.Maps.cb.pick.share_events.html) now supports the additional kwarg `"ensure_same_id"`
  - If True, all maps that share the pick-event will use the same ID to identify the relevant datapoint
  - If False, all maps that share the pick-event identify the closest datapoint based on the (reprojected) click position.
- The `LayoutEditor` now accepts `-1` as width/height value for axes (to auto-adjust the value)

### 🕹️ Jupyter Widgets

There is now a collection of pre-configured [Jupyter Widgets](https://ipywidgets.readthedocs.io/en/latest/index.html) that can be used as control elements in **Jupyter Notebooks**!

> Make sure to checkout the corresponding  [🕹️ EOmaps Jupyter Widgets](https://eomaps.readthedocs.io/en/widgets/notebooks/widgets.html) section in the docs!


# 🌦️ Changes
- ❗ Installation config is now provided as a `pyproject.toml` file (instead of `setup.py`)
- ❗ Supported python version is now `>=3.8`
- EOmaps now uses [qtpy](https://github.com/spyder-ide/qtpy) to support multiple Qt versions for the [🧰 Companion Widget](https://eomaps.readthedocs.io/en/latest/api_companion_widget.html)!
- `_version.py` has been removed. The version is now specified in the `[project]` category of the `pyproject.toml` file.
- Actions now use `micromamba` to setup (and cache) test environments
- Colorbar kwargs `show_outline` and `ylabel` have been renamed to `outline` and `hist_label`

> The following (previously deprecated) methods are now removed:
> - `m.set_data_specs` $\Rightarrow$ use ``m.set_data`` instead
> - `m.add_wms.DLR_basemaps...` $\Rightarrow$ use ``m.add_wms.DLR.basemap...`` instead
> - `m_inset.indicate_inset_extent` $\Rightarrow$ use ``m_inset.add_extent_indicator`` instead


# 📖 Documentation updates

### Make sure to checkout the fully updated [API docs](https://eomaps.readthedocs.io/en/dev/api/reference.html)! 

- Documentation environment was updated to most recent build dependencies
- Only minimal requirements to import eomaps are now installed for docs-build
- Info on how to [configure VSCode/VSCodium](https://eomaps.readthedocs.io/en/dev/FAQ.html#configuring-the-editor-ide) for EOmaps has been added to the docs
- In general, the docs now (gradually switch to) use [MySt](https://mystmd.org/) and Jupyter Notebooks (parsed with [myst_nb](https://myst-nb.readthedocs.io/en/latest/index.html)) to improve formatting, examples etc.


# 🔨 Fixes
- Make sure the widget is compatible with both Qt5 and Qt6
- Fix forcing colorbar-position inheritance
- Fix treatment of colorbar histogram style kwargs (e.g. edgecolor, facecolor, etc.)
- Address `numpy` binary incompatibility warning if `netCDF4` is imported after numpy
- Fix inheriting colorbar positions from other colorbars
- Address unittest issue with contour-shape labels
- Avoid blocking the terminal in unittests for jupyter notebooks
- Fix missing docstring for DLR webmap service
- Fix issues for move-callbacks shared between multiple Maps 
- Fix visibility of datasets when using "dynamic_shade_indicator" colorbars 
- Fix assignment of vmin/vmax for "count" based shade-aggregation
- Fix treatment of masked values in evaluation of vmin/vmax for encoded datasets 
- Fix issues with help-text popups of the CompanionWidget LayerTabBar
- Improvements for colorbar implementation
- Unify treatment of layer-name parsing
- Try to push current view to toolbar nav-stack after layout-restore
- Fix issues with help-popups of the LayerTabBar of the companion-widget
- Fix issues with figure-exports after `m.apply_layout(...)`
- Fix treatment of reprojected 1D datasets with `shade_raster` shape
- Fix parsing *maxsize* argument in companion widget for `raster`-shape
- Fix treatment of infinite values in weighted colorbar histograms
- Allow passing transform-kwarg to `m.add_text(...)`
- Fix truncating companion-widget title if too long
- Make sure companion-widget dataset-dropdown is elided
- Avoid memory-leaks caused by artist-references in pick-containers
- Fix `numpy.ma.masked_array` issues with datashader/numba when using `"shade_points"`
- Fix handling pick-events that do not have an "idx" property 
- Fix raster-aggregation if block-size cannot be evaluated (e.g. None)
- Fix handling of pick-events that do not have an "idx" property
- Make sure keypress-events are triggered irrespective of the toolbar mode
- Make sure LayoutEditor x0, y0 values are always set as specified
- Fix issues with string-type dpi values passed to savefig 
- Avoid pandas dependency when attempting to use `raster` shape with 1D datasets
- Make sure data encoding fill-value is properly applied