### PR TITLE
merge for v8.2.1

### DIFF
--- a/eomaps/_blit_manager.py
+++ b/eomaps/_blit_manager.py
@@ -574,7 +574,11 @@ class BlitManager(LayerParser):
             # artists that are only visible if both layers are visible! (e.g. "l1|l2")
             artists.extend(self._bg_artists.get(l, []))
 
-            if l == self._unmanaged_artists_layer:
+            # make sure to also trigger drawing unmanaged artists on inset-maps!
+            if l in (
+                self._unmanaged_artists_layer,
+                f"__inset_{self._unmanaged_artists_layer}",
+            ):
                 artists.extend(self._get_unmanaged_artists())
 
         # make the list unique but maintain order (dicts keep order for python>3.7)

--- a/eomaps/_data_manager.py
+++ b/eomaps/_data_manager.py
@@ -681,7 +681,7 @@ class DataManager:
 
         # don't re-draw if the layer of the dataset is not requested
         # (note multi-layers trigger re-draws of individual layers as well)
-        if layer not in ["all", self.layer]:
+        if not self.m.BM._layer_is_subset(layer, self.layer):
             return False
 
         # don't re-draw if the collection has been hidden in the companion-widget
@@ -891,7 +891,6 @@ class DataManager:
 
             s = self._get_datasize(**props)
             self._print_datasize_warnings(s)
-
             # stop here in case we are dealing with a pick-only dataset
             if self._only_pick:
                 return

--- a/eomaps/_data_manager.py
+++ b/eomaps/_data_manager.py
@@ -940,9 +940,9 @@ class DataManager:
 
             self.m.cb.pick._set_artist(coll)
 
-        except Exception:
+        except Exception as ex:
             _log.exception(
-                f"EOmaps: Unable to plot the data for the layer '{layer}'!",
+                f"EOmaps: Unable to plot the data for the layer '{layer}'!\n{ex}",
                 exc_info=_log.getEffectiveLevel() <= logging.DEBUG,
             )
 

--- a/eomaps/_maps_base.py
+++ b/eomaps/_maps_base.py
@@ -144,6 +144,94 @@ class _MapsMeta(type):
         if log_level is not None:
             set_loglevel(log_level)
 
+    def apply_webagg_fix(cls):
+        """
+        Apply fix to avoid slow updates and lags due to event-accumulation in webagg backend.
+
+        (e.g. when using `matplotlib.use("webagg")`)
+
+        - Events that occur while draws are pending are dropped and only the
+          last event of each type that occured during the wait is finally executed.
+
+        Note
+        ----
+
+        Using this fix is **experimental** and will monkey-patch matplotlibs
+        `FigureCanvasWebAggCore` and `FigureManagerWebAgg` to avoid event accumulation!
+
+        You MUST call this function at the very beginning of the script to ensure
+        changes are applied correctly!
+
+        There might be unwanted side-effects for callbacks that require all events
+        to be executed consecutively independent of the draw-state (e.g. typing text).
+
+        """
+        from matplotlib.backends.backend_webagg_core import (
+            FigureCanvasWebAggCore,
+            FigureManagerWebAgg,
+        )
+
+        def handle_ack(self, event):
+            self._ack_cnt += 1  # count the number of received images
+
+        def refresh_all(self):
+            if self.web_sockets:
+                diff = self.canvas.get_diff_image()
+                if diff is not None:
+                    for s in self.web_sockets:
+                        s.send_binary(diff)
+
+                    self._send_cnt += 1  # count the number of sent images
+
+        def handle_event(self, event):
+            if not hasattr(self, "_event_cache"):
+                self._event_cache = dict()
+
+            cnt_equal = self._ack_cnt == self.manager._send_cnt
+
+            # always process ack and draw events
+            # process other events only if "ack count" equals "send count"
+            # (e.g. if we received and handled all pending images)
+            if cnt_equal or event["type"] in ["ack", "draw"]:
+                # immediately process all cached events
+                for cache_event_type, cache_event in self._event_cache.items():
+                    getattr(
+                        self,
+                        "handle_{0}".format(cache_event_type),
+                        self.handle_unknown_event,
+                    )(cache_event)
+                self._event_cache.clear()
+
+                # reset counters to avoid overflows (just a precaution to avoid overflows)
+                if cnt_equal:
+                    self._ack_cnt, self.manager._send_cnt = 0, 0
+
+                # process event
+                e_type = event["type"]
+                handler = getattr(
+                    self, "handle_{0}".format(e_type), self.handle_unknown_event
+                )
+            else:
+                # ignore events in case we have a pending image that is on the way to be processed
+                # cache the latest event of each type so we can process it once we are ready
+                self._event_cache[event["type"]] = event
+
+                # a final savety precaution in case send count is lower than ack count
+                # (e.g. we wait for an image but there was no image sent)
+                if self.manager._send_cnt < self._ack_cnt:
+                    # reset counts... they seem to be incorrect
+                    self._ack_cnt, self.manager._send_cnt = 0, 0
+                return
+
+            return handler(event)
+
+        FigureCanvasWebAggCore._ack_cnt = 0
+        FigureCanvasWebAggCore.handle_ack = handle_ack
+        FigureCanvasWebAggCore.handle_event = handle_event
+
+        FigureManagerWebAgg._send_cnt = 0
+        FigureManagerWebAgg.refresh_all = refresh_all
+
 
 class MapsBase(metaclass=_MapsMeta):
     def __init__(

--- a/eomaps/colorbar.py
+++ b/eomaps/colorbar.py
@@ -631,6 +631,8 @@ class ColorBar(ColorBarBase):
 
     """
 
+    max_n_classify_bins_to_label = 30
+
     def __init__(self, *args, inherit_position=True, layer=None, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -1197,9 +1199,11 @@ class ColorBar(ColorBarBase):
             return
 
         if self._m._classified:
-            self.cb.set_ticks(
-                np.unique(np.clip(self._m.classify_specs._bins, self._vmin, self._vmax))
+            unique_bins = np.unique(
+                np.clip(self._m.classify_specs._bins, self._vmin, self._vmax)
             )
+            if len(unique_bins) <= self.max_n_classify_bins_to_label:
+                self.cb.set_ticks(unique_bins)
 
         if self.orientation == "horizontal":
             if self._m._classified:

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -363,6 +363,18 @@ class Maps(MapsBase):
         return self._coll
 
     @property
+    def _shape_assigned(self):
+        """Return True if the shape is explicitly assigned and False otherwise"""
+        # the shape is considered assigned if an explicit shape is set
+        # or if the data has been plotted with the default shape
+
+        q = self._shape is None or (
+            getattr(self._shape, "_is_default", False) and not self._data_plotted
+        )
+
+        return not q
+
+    @property
     def shape(self):
         """
         The shape that is used to represent the dataset if `m.plot_map()` is called.
@@ -372,13 +384,8 @@ class Maps(MapsBase):
         for 2D datasets and "shade_points" is used for unstructured datasets.
 
         """
-        # make sure the default shape is re-checked every time until
-        # data is effectively plotted or an explicit shape is set.
-        check_default = self._shape is None or (
-            getattr(self._shape, "_is_default", False) and not self._data_plotted
-        )
 
-        if check_default:
+        if not self._shape_assigned:
             self._set_default_shape()
             self._shape._is_default = True
 
@@ -538,7 +545,7 @@ class Maps(MapsBase):
             m2.inherit_data(self)
         if inherit_classification:
             m2.inherit_classification(self)
-        if inherit_shape:
+        if inherit_shape and self._shape_assigned:
             getattr(m2.set_shape, self.shape.name)(**self.shape._initargs)
 
         if np.allclose(self.ax.bbox.bounds, m2.ax.bbox.bounds):
@@ -669,7 +676,7 @@ class Maps(MapsBase):
             m.inherit_data(self)
         if inherit_classification:
             m.inherit_classification(self)
-        if inherit_shape:
+        if inherit_shape and self._shape_assigned:
             getattr(m.set_shape, self.shape.name)(**self.shape._initargs)
 
         # make sure the new layer does not attempt to reset the extent if

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -372,7 +372,9 @@ class Maps(MapsBase):
         for 2D datasets and "shade_points" is used for unstructured datasets.
 
         """
-        if self._shape is None:
+        # make sure the default shape is re-checked every time until
+        # data is effectively plotted or an explicit shape is set.
+        if self._shape is None or not self._data_plotted:
             self._set_default_shape()
 
         return self._shape

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -3500,8 +3500,16 @@ class Maps(MapsBase):
             if vmax > max(bins):
                 bins = [*bins, vmax]
 
-            cbcmap = cmap
-            norm = mpl.colors.BoundaryNorm(bins, cmap.N)
+            # TODO Always use resample once mpl>3.6 is pinned
+            if hasattr(cmap, "resampled"):
+                # Resample colormap to contain enough color-values
+                # as needed by the boundary-norm.
+                if len(bins) > cmap.N:
+                    cbcmap = cmap.resampled(len(bins))
+            else:
+                cbcmap = cmap
+
+            norm = mpl.colors.BoundaryNorm(bins, cbcmap.N)
 
             self._emit_signal("cmapsChanged")
 

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -3501,11 +3501,10 @@ class Maps(MapsBase):
                 bins = [*bins, vmax]
 
             # TODO Always use resample once mpl>3.6 is pinned
-            if hasattr(cmap, "resampled"):
+            if hasattr(cmap, "resampled") and len(bins) > cmap.N:
                 # Resample colormap to contain enough color-values
                 # as needed by the boundary-norm.
-                if len(bins) > cmap.N:
-                    cbcmap = cmap.resampled(len(bins))
+                cbcmap = cmap.resampled(len(bins))
             else:
                 cbcmap = cmap
 

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -2765,8 +2765,9 @@ class Maps(MapsBase):
         else:
             if "norm" in kwargs:
                 norm = kwargs.pop("norm")
-                norm.vmin = self._vmin
-                norm.vmax = self._vmax
+                if not isinstance(norm, str):  # to allow datashader "eq_hist" norm
+                    norm.vmin = self._vmin
+                    norm.vmax = self._vmax
             else:
                 norm = plt.Normalize(vmin=self._vmin, vmax=self._vmax)
 

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -374,8 +374,13 @@ class Maps(MapsBase):
         """
         # make sure the default shape is re-checked every time until
         # data is effectively plotted or an explicit shape is set.
-        if self._shape is None or not self._data_plotted:
+        check_default = self._shape is None or (
+            getattr(self._shape, "_is_default", False) and not self._data_plotted
+        )
+
+        if check_default:
             self._set_default_shape()
+            self._shape._is_default = True
 
         return self._shape
 

--- a/eomaps/shapes.py
+++ b/eomaps/shapes.py
@@ -426,6 +426,11 @@ class Shapes(object):
                 if m._data_manager.x0 is None:
                     m._data_manager.set_props(None)
 
+                # check if the first element of x0 is nonzero...
+                # (to avoid slow performance of np.any for large arrays)
+                if not np.any(m._data_manager.x0.take(0)):
+                    return None
+
                 _log.info("EOmaps: Estimating shape radius...")
                 radiusx, radiusy = Shapes._estimate_radius(m, radius_crs)
 

--- a/eomaps/widgets.py
+++ b/eomaps/widgets.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 from . import _log
 from ._blit_manager import LayerParser
@@ -10,16 +9,6 @@ try:
     import ipywidgets
 except ImportError:
     _log.warning("EOmaps-widgets are missing the required dependency 'ipywidgets'!")
-
-
-def _check_backend():
-    backend = plt.get_backend()
-    if "ipympl" not in backend.lower():
-        _log.warning(
-            "EOmaps-widgets only work with the 'ipympl (widget)' backend! "
-            "Make sure you have 'ipympl' installed and use the magic-command "
-            "'%matplotlib widget' to switch to the interactive jupyter backend!"
-        )
 
 
 @contextmanager
@@ -100,8 +89,6 @@ class _LayerSelectionWidget:
     _widget_cls = None
 
     def __init__(self, m, layers=None, **kwargs):
-        _check_backend()
-
         self._m = m
         self._set_layers_options(layers)
 
@@ -336,8 +323,6 @@ class LayerButton(ipywidgets.Button):
 
     def __init__(self, m, layer, **kwargs):
         self._m = m
-        _check_backend()
-
         self._layer = self._parse_layer(layer)
 
         kwargs.setdefault("description", self._layer)
@@ -386,8 +371,6 @@ class LayerOverlaySlider(ipywidgets.FloatSlider):
 
     def __init__(self, m, layer, **kwargs):
         self._m = m
-        _check_backend()
-
         self._layer = layer
 
         kwargs.setdefault("value", 0)
@@ -449,8 +432,6 @@ class _CallbackWidget:
 
     def __init__(self, m, widget_kwargs=None, **kwargs):
         self._m = m
-        _check_backend()
-
         self._kwargs = kwargs
 
         if widget_kwargs is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ eomaps = ["logo.png", "NE_features.json", "qtcompanion/icons/*"]
 
 [project]
 name = "eomaps"
-version = "8.2"
+version = "8.2.1"
 description = "A library to create interactive maps of geographical datasets."
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
A first series of bugfixes for v8.2

## 🔨 Fixes
- ❗Fix identification of default shape based on dataset size
- ❗Fix issues with unmanaged artists on inset-maps
- Explicitly check if norm is provided as string before setting data limits
- Provide more descriptive (info) error message if data cannot be plotted
- Avoid using classification bins as labels if a large number of bins is used (>30)
- Make sure to resample colormaps in case more bins than colors are used
- Avoid shape radius estimation if no data is set
- Avoid unnecessary draw-triggers for datasets if the "all" layer is visible
- Remove warning for widgets if backends other than "ipympl" are used