### PR TITLE
V8.3.2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,8 @@
 version: 2
 
+sphinx:
+  configuration: docs/source/conf.py
+
 build:
   os: "ubuntu-20.04"
   tools:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <p align="center">
     <a href=https://github.com/raphaelquast/EOmaps>
-    <img src="https://github.com/raphaelquast/EOmaps/blob/master/docs/_static/logo.png?raw=true" alt="EOmaps logo" width="55%">
+    <img src="https://github.com/raphaelquast/EOmaps/blob/master/docs/source/_static/logo.png?raw=true" alt="EOmaps logo" width="55%">
     </a>
 </p>
 

--- a/docs/source/FAQ.rst
+++ b/docs/source/FAQ.rst
@@ -95,7 +95,7 @@ However, for some editors there are special settings that can be adjusted to imp
 
       To print a snapshot of the current state of a figure to the IPython terminal, call :py:meth:`Maps.show` or :py:meth:`Maps.snapshot`.
 
-    - Similar to Jupyter Notebooks, you can use *"magic"* commands to set the used matpltolib backend.
+    - Similar to Jupyter Notebooks, you can use *"magic"* commands to set the used matplotlib backend.
 
       - For interactive (popup) figures, switch to the default Qt backend using ``%matplotlib qt``
       - For interactive (inline) figures, you'll need to install `ipympl <https://github.com/matplotlib/ipympl>`_ and then activate the ``widget`` with ``%matplotlib widget``.

--- a/docs/source/_static/version_switcher.json
+++ b/docs/source/_static/version_switcher.json
@@ -9,8 +9,8 @@
     "url": "https://eomaps.readthedocs.io/en/dev/"
   },
   {
-    "version": "v8.3.1",
-    "url": "https://eomaps.readthedocs.io/en/v8.3.1/"
+    "version": "v8.3.2",
+    "url": "https://eomaps.readthedocs.io/en/v8.3.2/"
   },
   {
     "version": "v8.2.1",

--- a/docs/source/_static/version_switcher.json
+++ b/docs/source/_static/version_switcher.json
@@ -9,8 +9,8 @@
     "url": "https://eomaps.readthedocs.io/en/dev/"
   },
   {
-    "version": "v8.3",
-    "url": "https://eomaps.readthedocs.io/en/v8.3/"
+    "version": "v8.3.1",
+    "url": "https://eomaps.readthedocs.io/en/v8.3.1/"
   },
   {
     "version": "v8.2.1",

--- a/docs/source/api/eomaps.eomaps.Maps.rst
+++ b/docs/source/api/eomaps.eomaps.Maps.rst
@@ -235,6 +235,7 @@ Miscellaneous
     :template: obj_with_attributes_no_toc.rst
     :nosignatures:
 
+    Maps.delay_draw
     Maps.fetch_companion_wms_layers
     Maps.refetch_wms_on_size_change
     Maps.cleanup

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,7 +56,7 @@ def mpl_rc_role_subst(name, rawtext, text, lineno, inliner, options={}, content=
 
     node = reference(
         "",
-        f"matpltolib rcParams['{text}']",
+        f"matplotlib rcParams['{text}']",
         refuri=r"https://matplotlib.org/stable/users/explain/customizing.html#matplotlibrc-sample",
     )
     return [node], []

--- a/docs/source/user_guide/how_to_use/api_basics.rst
+++ b/docs/source/user_guide/how_to_use/api_basics.rst
@@ -393,7 +393,7 @@ To adjust the margins of the subplots, use :py:meth:`m.subplots_adjust`, or have
 Multiple Maps/Plots in one Figure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is possible to combine multiple ``EOmaps`` maps and/or ordinary ``matpltolib`` plots in one figure.
+It is possible to combine multiple ``EOmaps`` maps and/or ordinary ``matplotlib`` plots in one figure.
 
 The **figure** used by a :py:class:`Maps` object is set via the ``f`` argument, e.g.: ``m = Maps(f=...)``.
 If no figure is provided, a new figure is created whenever you initialize a :py:class:`Maps` object.
@@ -714,7 +714,7 @@ MapsGrid objects
     the preferred way of combining multiple maps and/or matplotlib axes in a figure
     is by using one of the options presented in the previous sections!
 
-A :py:class:`MapsGrid` creates a grid of :py:class:`Maps` objects (and/or ordinary ``matpltolib`` axes),
+A :py:class:`MapsGrid` creates a grid of :py:class:`Maps` objects (and/or ordinary ``matplotlib`` axes),
 and provides convenience-functions to perform actions on all maps of the figure.
 
 .. code-block:: python
@@ -768,7 +768,7 @@ of the following structure:
 - ``m_inits`` is used to initialize :py:class:`Maps` objects
 - ``ax_inits`` is used to initialize ordinary ``matplotlib`` axes
 
-The individual :py:class:`Maps` objects and ``matpltolib-Axes`` are then accessible via:
+The individual :py:class:`Maps` objects and ``matplotlib-Axes`` are then accessible via:
 
 .. code-block:: python
     :name: test_mapsgrid_custom

--- a/docs/source/user_guide/how_to_use/api_data_visualization.rst
+++ b/docs/source/user_guide/how_to_use/api_data_visualization.rst
@@ -878,7 +878,7 @@ Colors can also be set **manually** by providing one of the following arguments 
 Uniform colors
 **************
 
-To apply a uniform color to all datapoints, you can use `matpltolib's named colors <https://matplotlib.org/stable/gallery/color/named_colors.html>`_ or pass an RGB or RGBA tuple.
+To apply a uniform color to all datapoints, you can use `matplotlib's named colors <https://matplotlib.org/stable/gallery/color/named_colors.html>`_ or pass an RGB or RGBA tuple.
 
 - ``m.plot_map(fc="orange")``
 - ``m.plot_map(fc=(0.4, 0.3, 0.2))``

--- a/eomaps/_blit_manager.py
+++ b/eomaps/_blit_manager.py
@@ -1081,7 +1081,7 @@ class BlitManager(LayerParser):
 
         Parameters
         ----------
-        art : matpltolib.Artist
+        art : matplotlib.Artist
             The artist to remove.
         layer : str, optional
             The layer to search for the artist. If None, all layers are searched.
@@ -1403,7 +1403,7 @@ class BlitManager(LayerParser):
         ----------
         artists : iterable
             the artists to draw
-        bg : matpltolib.BufferRegion, None or "active", optional
+        bg : matplotlib.BufferRegion, None or "active", optional
             A fetched background that is restored before drawing the artists.
             The default is "active".
         blit : bool

--- a/eomaps/_maps_base.py
+++ b/eomaps/_maps_base.py
@@ -439,7 +439,7 @@ class MapsBase(metaclass=_MapsMeta):
 
     def _init_figure(self, **kwargs):
         if self.parent.f is None:
-            # do this on any new figure since "%matpltolib inline" tries to re-activate
+            # do this on any new figure since "%matplotlib inline" tries to re-activate
             # interactive mode all the time!
             _handle_backends()
 

--- a/eomaps/_maps_base.py
+++ b/eomaps/_maps_base.py
@@ -447,13 +447,6 @@ class MapsBase(metaclass=_MapsMeta):
             # to hide canvas header in jupyter notebooks (default figure label)
             self._f.canvas.header_visible = False
 
-            # override Figure.savefig with Maps.savefig but keep original
-            # method accessible via Figure._mpl_orig_savefig
-            # (this ensures that using the save-buttons in the gui or pressing
-            # control+s will redirect the save process to the eomaps routine)
-            self._f._mpl_orig_savefig = self._f.savefig
-            self._f.savefig = self.savefig
-
             _log.debug("EOmaps: New figure created")
 
             # make sure we keep a "real" reference otherwise overwriting the
@@ -466,6 +459,14 @@ class MapsBase(metaclass=_MapsMeta):
             self.parent._add_child(self)
 
         if self.parent == self:  # use == instead of "is" since the parent is a proxy!
+
+            # override Figure.savefig with Maps.savefig but keep original
+            # method accessible via Figure._mpl_orig_savefig
+            # (this ensures that using the save-buttons in the gui or pressing
+            # control+s will redirect the save process to the eomaps routine)
+            self._f._mpl_orig_savefig = self._f.savefig
+            self._f.savefig = self.savefig
+
             # only attach resize- and close-callbacks if we initialize a parent
             # Maps-object
             # attach a callback that is executed when the figure is closed

--- a/eomaps/_maps_base.py
+++ b/eomaps/_maps_base.py
@@ -1163,7 +1163,12 @@ class MapsBase(metaclass=_MapsMeta):
     def _get_cartopy_crs(crs):
         if isinstance(crs, str):
             try:
-                crs = int(crs.upper().removeprefix("EPSG:"))
+                # TODO use crs=int(crs.upper().removeprefix("EPSG:")) when python>=3.9
+                # is required
+                crs = crs.upper()
+                if crs.startswith("EPSG:"):
+                    crs = crs[5:]
+                crs = int(crs)
             except ValueError:
                 raise ValueError(
                     f"The provided crs '{crs}' cannot be identified. "

--- a/eomaps/_maps_base.py
+++ b/eomaps/_maps_base.py
@@ -1169,7 +1169,7 @@ class MapsBase(metaclass=_MapsMeta):
                     f"The provided crs '{crs}' cannot be identified. "
                     "If a string is provided as CRS, it must be either an integer "
                     "(e.g. '4326') or a string of the form: 'EPSG:4326'."
-                    )
+                )
         if isinstance(crs, ccrs.CRS):  # already a cartopy CRS
             cartopy_proj = crs
         elif crs == 4326:

--- a/eomaps/_maps_base.py
+++ b/eomaps/_maps_base.py
@@ -1161,6 +1161,15 @@ class MapsBase(metaclass=_MapsMeta):
     @staticmethod
     @lru_cache()
     def _get_cartopy_crs(crs):
+        if isinstance(crs, str):
+            try:
+                crs = int(crs.upper().removeprefix("EPSG:"))
+            except ValueError:
+                raise ValueError(
+                    f"The provided crs '{crs}' cannot be identified. "
+                    "If a string is provided as CRS, it must be either an integer "
+                    "(e.g. '4326') or a string of the form: 'EPSG:4326'."
+                    )
         if isinstance(crs, ccrs.CRS):  # already a cartopy CRS
             cartopy_proj = crs
         elif crs == 4326:

--- a/eomaps/_webmap.py
+++ b/eomaps/_webmap.py
@@ -132,7 +132,7 @@ class _WebMapLayer:
 
         Returns
         -------
-        legax : matpltolib.axes
+        legax : matplotlib.axes
             The axes-object.
 
         """

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -155,9 +155,9 @@ class Maps(MapsBase):
         - A 3-digit integer
             Same as using a tuple of three single-digit integers.
             (e.g. 111 is the same as (1, 1, 1) )
-        - `matplotilb.gridspec.SubplotSpec`:
+        - `matplotlib.gridspec.SubplotSpec`:
             Use the SubplotSpec for initializing the axes.
-        - `matplotilb.Axes`:
+        - `matplotlib.Axes`:
             Directly use the provided figure and axes instances for plotting.
             NOTE: The axes MUST be a geo-axes with `m.crs_plot` projection!
     preferred_wms_service : str, optional
@@ -532,9 +532,9 @@ class Maps(MapsBase):
             - A 3-digit integer
                 Same as using a tuple of three single-digit integers.
                 (e.g. 111 is the same as (1, 1, 1) )
-            - `matplotilb.gridspec.SubplotSpec`:
+            - `matplotlib.gridspec.SubplotSpec`:
                 Use the SubplotSpec for initializing the axes.
-            - `matplotilb.Axes`:
+            - `matplotlib.Axes`:
                 Directly use the provided figure and axes instances for plotting.
                 NOTE: The axes MUST be a geo-axes with `m.crs_plot` projection!
         keep_on_top : bool
@@ -2367,7 +2367,7 @@ class Maps(MapsBase):
         mark_points : str, dict or None, optional
             Set the marker-style for the anchor-points.
 
-            - If a string is provided, it is identified as a matploltib "format-string",
+            - If a string is provided, it is identified as a matplotlib "format-string",
               e.g. "r." for red dots, "gx" for green x markers etc.
             - if a dict is provided, it will be used to set the style of the markers
               e.g.: dict(marker="o", facecolor="orange", edgecolor="g")
@@ -2748,7 +2748,7 @@ class Maps(MapsBase):
             circle with a red boundary.
 
             If a dict is provided, it can be used to update the appearance of the
-            masked points (arguments are passed to matpltolibs `plt.scatter()`)
+            masked points (arguments are passed to matplotlibs `plt.scatter()`)
             ('s': markersize, 'marker': the shape of the marker, ...)
 
             The default is False
@@ -2761,7 +2761,7 @@ class Maps(MapsBase):
             The zorder of the artist (e.g. the stacking level of overlapping artists)
             The default is 1
         kwargs
-            kwargs passed to the initialization of the matpltolib collection
+            kwargs passed to the initialization of the matplotlib collection
             (dependent on the plot-shape) [linewidth, edgecolor, facecolor, ...]
 
             For "shade_points" or "shade_raster" shapes, kwargs are passed to

--- a/eomaps/inset_maps.py
+++ b/eomaps/inset_maps.py
@@ -126,7 +126,7 @@ class InsetMaps(Maps):
         (x0, y0), (x1, y1) = bnd_verts.min(axis=0), bnd_verts.max(axis=0)
         self.ax.set_extent((x0, x1, y0, y1), crs=self.ax.projection)
 
-        # TODO turn off navigation until the matpltolib pull-request on
+        # TODO turn off navigation until the matplotlib pull-request on
         # zoom-events in overlapping axes is resolved
         # https://github.com/matplotlib/matplotlib/pull/22347
         # self.ax.set_navigate(False)

--- a/eomaps/shapes.py
+++ b/eomaps/shapes.py
@@ -16,7 +16,8 @@ from matplotlib.collections import Collection
 from pyproj import CRS
 import numpy as np
 
-from .helpers import register_modules
+from .helpers import register_modules, version, mpl_version
+
 
 _log = logging.getLogger(__name__)
 
@@ -2267,7 +2268,13 @@ class Shapes(object):
                         "x", "y", "z", data=data, **color_and_array
                     )
 
-            return _CollectionAccessor(cont, self._filled)
+            # from matplotlib v3.10 on the .collection kwarg is removed and
+            # since v3.8 ax.contour already returns a collection.
+            # TODO remove this once mpl >=3.10 is required
+            if mpl_version < version.Version("3.10"):
+                return _CollectionAccessor(cont, self._filled)
+            else:
+                return cont
 
         def get_coll(self, x, y, crs, **kwargs):
             x, y = np.asanyarray(x), np.asanyarray(y)
@@ -2277,6 +2284,7 @@ class Shapes(object):
 
             coll = self._get_contourf_colls(x, y, crs, **kwargs)
 
+            # TODO remove this once mpl >= 3.10 is required
             if isinstance(coll, _CollectionAccessor):
                 for c in coll.collections:
                     self._m.BM._ignored_unmanaged_artists.add(c)

--- a/eomaps/shapes.py
+++ b/eomaps/shapes.py
@@ -2162,7 +2162,7 @@ class Shapes(object):
 
             Note
             ----
-            This is a wrapper for matpltolibs contour-plot capabilities.
+            This is a wrapper for matplotlibs contour-plot capabilities.
 
             - contours for 2D datasets are evaluated with `plt.contour`
             - contours for 1D datasets are evaluated with `plt.tricontour`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ eomaps = ["logo.png", "NE_features.json", "qtcompanion/icons/*"]
 
 [project]
 name = "eomaps"
-version = "8.3"
+version = "8.3.1"
 description = "A library to create interactive maps of geographical datasets."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
     "scipy",
     "matplotlib>=3.4",
     "cartopy>=0.20.0",
-    "descartes",
     "pyproj",
     "packaging",
     "click"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ eomaps = ["logo.png", "NE_features.json", "qtcompanion/icons/*"]
 
 [project]
 name = "eomaps"
-version = "8.3.1"
+version = "8.3.2"
 description = "A library to create interactive maps of geographical datasets."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/test_basic_functions.py
+++ b/tests/test_basic_functions.py
@@ -95,7 +95,7 @@ class TestBasicPlotting(unittest.TestCase):
         plt.close("all")
 
         # rectangles
-        m = Maps(4326)
+        m = Maps("EPSG:4326")
         m.set_data(usedata, x="x", y="y", crs=3857)
         m.set_classify.EqualInterval(k=5)
         m.set_shape.rectangles()


### PR DESCRIPTION
A minor release that addresses some pending issues.

## 🔨 Fixes

- ❗fix `m.set_shape.contour()` if `matplotlib >=3.10` is used
- fix `AttributeError: 'Figure' object has no attribute '_mpl_orig_savefig'` 
- fix readthedocs builds (e.g. add _"sphinx configuration key"_)

## 🌳 New
- You can now provide the crs also as a string, e.g: `m = Maps(crs="EPSG:4326")`