### PR TITLE
Fix typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,9 @@ repos:
     rev: 22.3.0
     hooks:
     -   id: black
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+    -   id: codespell
+        additional_dependencies:
+        -   tomli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,4 +17,4 @@ repos:
     hooks:
     -   id: codespell
         additional_dependencies:
-        -   tomli
+        -   tomli  # TODO only required for python < 3.11

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ conda install -c conda-forge eomaps
 
 
 > Advanced users can also use `pip` to install **EOmaps** (and selectively install optional dependency groups)
-> ```pyhton
+> ```python
 > pip install eomaps       # install only minimal required dependencies
 > pip install eomaps[all]  # install all optional dependencies
 > ...

--- a/docs/source/FAQ.rst
+++ b/docs/source/FAQ.rst
@@ -216,7 +216,7 @@ Most notably (start of 2024), the **required dependency** `cartopy <https://gith
 
 .. tip::
 
-    If you want to get a quick overview of the licenses of an existing pyhton environment, I recommend having a look at the `pip-licenses <https://github.com/raimon49/pip-licenses>`_ package!
+    If you want to get a quick overview of the licenses of an existing python environment, I recommend having a look at the `pip-licenses <https://github.com/raimon49/pip-licenses>`_ package!
 
 
 Important changes between major versions

--- a/docs/source/contribute/contribute.rst
+++ b/docs/source/contribute/contribute.rst
@@ -153,6 +153,7 @@ To ensure uniform code style, EOmaps uses `pre-commit hooks <https://pre-commit.
 - Removal of trailing whitespaces in `.py` files
 - Making sure that files end with a newline
 - Compliance to the used `black <https://github.com/psf/black>`_ code formatting standards
+- Making sure files don't contain common typos as detected by the `codespell <https://github.com/codespell-project/codespell>`_ spell checker
 
 
 To initialize pre-commit hooks in your current environment, first install `pre-commit hooks <https://pre-commit.com/>`_ with
@@ -183,6 +184,7 @@ This will install the required pre-commit hooks in your current environment so t
     trim trailing whitespace.................................................Passed
     mixed line ending........................................................Passed
     black....................................................................Passed
+    codespell................................................................Passed
 
 
 .. note::
@@ -204,6 +206,9 @@ This will install the required pre-commit hooks in your current environment so t
   `pre-commit Issue #2178 comment <https://github.com/pre-commit/pre-commit/issues/2178#issuecomment-1002163763>`_
   for a potential resolution.
 
+.. tip::
+
+    - When using the `codespell` spell checker, false positives are possible. You should add these to the `[tool.codespell.ignore-words-list]` list in the `pyproject.toml` file.
 
 
 

--- a/docs/source/user_guide/how_to_use/api_basics.rst
+++ b/docs/source/user_guide/how_to_use/api_basics.rst
@@ -759,7 +759,7 @@ of the following structure:
 .. code-block:: python
 
     dict(
-        name1 = N  # position the axis at the Nth grid cell (counting firs)
+        name1 = N  # position the axis at the Nth grid cell (counting first)
         name2 = (row, col), # position the axis at the (row, col) grid-cell
         name3 = (row, slice(col_start, col_end)) # span the axis over multiple columns
         name4 = (slice(row_start, row_end), col) # span the axis over multiple rows

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -5,7 +5,7 @@ User guide
 ==========
 
 
-The following chapters provide detailed informatio on how to use EOmaps
+The following chapters provide detailed information on how to use EOmaps
 with a lot of code-examples!
 
 

--- a/docs/source/user_guide/miscellaneous/api_read_data.rst
+++ b/docs/source/user_guide/miscellaneous/api_read_data.rst
@@ -64,7 +64,7 @@ Create a new Map from a file
 
     m = Maps.from_file.GeoTIFF(
         "the filepath",
-        classify_specs=dict(Maps.CLASSFIERS.Quantiles, k=10),
+        classify_specs=dict(Maps.CLASSIFIERS.Quantiles, k=10),
         cmap="RdBu"
         )
     m.add_colorbar()
@@ -95,7 +95,7 @@ Similar to :py:class:`Maps.from_file` , a new layer based on a file can be added
         coords=("longitude", "latitude"),
         data_crs=4326,
         isel=dict(time=123),
-        classify_specs=dict(Maps.CLASSFIERS.Quantiles, k=10),
+        classify_specs=dict(Maps.CLASSIFIERS.Quantiles, k=10),
         cmap="RdBu"
         )
 

--- a/eomaps/_blit_manager.py
+++ b/eomaps/_blit_manager.py
@@ -6,15 +6,15 @@
 """The BlitManager used to handle drawing and caching of backgrounds."""
 
 import logging
-from itertools import chain
-from contextlib import contextmanager, ExitStack
-from weakref import WeakSet
+from contextlib import ExitStack, contextmanager
 from functools import lru_cache
+from itertools import chain
+from weakref import WeakSet
 
-import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.transforms import Bbox
+import numpy as np
 from matplotlib.spines import Spine
+from matplotlib.transforms import Bbox
 
 _log = logging.getLogger(__name__)
 
@@ -840,7 +840,6 @@ class BlitManager(LayerParser):
         loglevel = _log.getEffectiveLevel()
 
         if hasattr(cv, "get_renderer") and not cv.is_saving():
-
             renderer = cv.get_renderer()
             if renderer is None:
                 # don't run if no renderer is available
@@ -886,7 +885,7 @@ class BlitManager(LayerParser):
 
             # workaround for nbagg backend to avoid glitches
             # it's slow but at least it works...
-            # check progress of the following issuse
+            # check progress of the following issues
             # https://github.com/matplotlib/matplotlib/issues/19116
             if self._mpl_backend_blit_fix:
                 self.update()
@@ -1368,7 +1367,7 @@ class BlitManager(LayerParser):
         if blit:
             # workaround for nbagg backend to avoid glitches
             # it's slow but at least it works...
-            # check progress of the following issuse
+            # check progress of the following issues
             # https://github.com/matplotlib/matplotlib/issues/19116
             if self._mpl_backend_force_full:
                 cv._force_full = True
@@ -1549,7 +1548,6 @@ class BlitManager(LayerParser):
             )
 
     def _cleanup_on_layer_activation(self, layer):
-
         try:
             # remove not yet executed lazy-activation methods
             # (e.g. not yet fetched WMS services)

--- a/eomaps/_maps_base.py
+++ b/eomaps/_maps_base.py
@@ -151,7 +151,7 @@ class _MapsMeta(type):
         (e.g. when using `matplotlib.use("webagg")`)
 
         - Events that occur while draws are pending are dropped and only the
-          last event of each type that occured during the wait is finally executed.
+          last event of each type that occurred during the wait is finally executed.
 
         Note
         ----
@@ -216,7 +216,7 @@ class _MapsMeta(type):
                 # cache the latest event of each type so we can process it once we are ready
                 self._event_cache[event["type"]] = event
 
-                # a final savety precaution in case send count is lower than ack count
+                # a final safety precaution in case send count is lower than ack count
                 # (e.g. we wait for an image but there was no image sent)
                 if self.manager._send_cnt < self._ack_cnt:
                     # reset counts... they seem to be incorrect

--- a/eomaps/_webmap.py
+++ b/eomaps/_webmap.py
@@ -1333,7 +1333,7 @@ class SlippyImageArtistNew(AxesImage):
     """
     A subclass of :class:`~matplotlib.image.AxesImage` which provides an
     interface for getting a raster from the given object with interactive
-    slippy map type functionality.
+    slippery map type functionality.
 
     Kwargs are passed to the AxesImage constructor.
 

--- a/eomaps/annotation_editor.py
+++ b/eomaps/annotation_editor.py
@@ -604,7 +604,7 @@ class AnnotationEditor(_EditorBase):
             The default is "all".
         sanitize_coordinates : bool, optional
             If Tue, annotation coordinates where the crs has not been specified
-            explicitly are reprojected to epsg=4326 to avoid amiguities (e.g. if the
+            explicitly are reprojected to epsg=4326 to avoid ambiguities (e.g. if the
             plot-crs changes etc.)
 
             If False, coordinates will be returned as-is (which might lead to incorrect

--- a/eomaps/eomaps.py
+++ b/eomaps/eomaps.py
@@ -3389,7 +3389,7 @@ class Maps(MapsBase):
     @wraps(MapsBase.savefig)
     def savefig(self, *args, refetch_wms=False, rasterize_data=True, **kwargs):
         with ExitStack() as stack:
-            # re-fetch webmap servies if required
+            # re-fetch webmap services if required
             if refetch_wms is False:
                 if _cx_refetch_wms_on_size_change is not None:
                     stack.enter_context(_cx_refetch_wms_on_size_change(refetch_wms))

--- a/eomaps/layout_editor.py
+++ b/eomaps/layout_editor.py
@@ -5,16 +5,16 @@
 
 """Definition of the LayoutEditor used to interactively re-position axes."""
 
+import json
 import logging
 from contextlib import ExitStack
 from pathlib import Path
-import json
 
 import numpy as np
-from matplotlib.lines import Line2D
-from matplotlib.transforms import Bbox
 from matplotlib.axis import XAxis, YAxis
+from matplotlib.lines import Line2D
 from matplotlib.spines import Spine
+from matplotlib.transforms import Bbox
 
 _log = logging.getLogger(__name__)
 
@@ -908,7 +908,7 @@ class LayoutEditor:
         It can only be re-applied to a given figure if the order at which the axes are
         created remains the same!
 
-        Maps aways preserve the aspect ratio.
+        Maps laways preserve the aspect ratio.
         If you provide values for width/height that do not match the aspect-ratio
         of the map, the values will be adjusted accordingly. By default, smaller values
         take precedence. To fix one value and adjust the other accordingly, use `-1`
@@ -1017,7 +1017,7 @@ class LayoutEditor:
         It can only be re-applied to a given figure if the order at which the axes are
         created remains the same!
 
-        Maps aways preserve the aspect ratio.
+        Maps always preserve the aspect ratio.
         If you provide values for width/height that do not match the aspect-ratio
         of the map, the values will be adjusted accordingly. By default, smaller values
         take precedence. To fix one value and adjust the other accordingly, use `-1`

--- a/eomaps/layout_editor.py
+++ b/eomaps/layout_editor.py
@@ -904,7 +904,7 @@ class LayoutEditor:
 
         Note
         ----
-        The layout is dependent on the order at which the axes ahve been created!
+        The layout is dependent on the order at which the axes have been created!
         It can only be re-applied to a given figure if the order at which the axes are
         created remains the same!
 
@@ -1013,7 +1013,7 @@ class LayoutEditor:
 
         Note
         ----
-        The layout is dependent on the order at which the axes ahve been created!
+        The layout is dependent on the order at which the axes have been created!
         It can only be re-applied to a given figure if the order at which the axes are
         created remains the same!
 

--- a/eomaps/webmap_containers.py
+++ b/eomaps/webmap_containers.py
@@ -2351,7 +2351,7 @@ class WebMapContainer(object):
             (check: https://basemap.at/#lizenz for full details)
 
             basemap.at ist gemäß der Open Government Data Österreich Lizenz
-            CC-BY 4.0 sowohl für private als auch kommerzielle Zwecke frei
+            CC-BY 4.0 sowohl für private also auch kommerzielle Zwecke frei
             sowie entgeltfrei nutzbar.
             """
 

--- a/eomaps/widgets.py
+++ b/eomaps/widgets.py
@@ -74,7 +74,7 @@ class _LayerSelectionWidget:
 
         >>> ["layer1", "layer2", ("layer", 0.4)]
 
-        To provide explict display-names for a layer, pass a list of the form
+        To provide explicit display-names for a layer, pass a list of the form
         `[display-name, <layer-assignment>]`
 
         >>> [["My Layer", "layer1"],
@@ -311,7 +311,7 @@ class LayerButton(ipywidgets.Button):
         The Maps-object to use.
     layer : str, list or tuple
         The layer to overlay.
-        Can be eiter a string, a tuple of a layer and a transparency or a list
+        Can be either a string, a tuple of a layer and a transparency or a list
         of the aforementioned types.
 
         See :py:meth:`Maps.show_layer` for more details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,16 @@ filterwarnings = [
     "ignore:Back azimuth is being returned by default *:UserWarning",
     "ignore:Conversion of an array with ndim > 0:DeprecationWarning"
 ]
+
+[tool.codespell]
+ignore-words-list = [
+    "vor", # For voronoi, not "for"
+    "ot", # abbreviation for offset-top
+]
+skip = [
+    "eomaps/webmap_containers.py", # Non-English languages in docstrings
+
+]
+ignore-regex = [
+    "[A-Za-z0-9+/]{100,}" # Ignore long base64 strings
+]


### PR DESCRIPTION
Some more typos. This time, I used [`codespell`](https://github.com/codespell-project/codespell) to detect these automatically.

If you like, I can configure this codespell tool as a pre-commit hook, so you can automatically detect any typos in the future.